### PR TITLE
Activating Open Collective

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,2 @@
+<!-- Love buttercup-desktop? Please consider supporting our collective:
+👉  https://opencollective.com/buttercup-desktop/donate -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,3 +35,41 @@ We've written tests and you can run them to assure the stability of the code, ju
 ### Documentation
 
 Every chunk of code that may be hard to understand has some comments above it. If you write some new code or change some part of the existing code in a way that it would not be functional without changing it's usages, it needs to be documented.
+
+
+## Financial contributions
+
+We also welcome financial contributions in full transparency on our [open collective](https://opencollective.com/buttercup-desktop).
+Anyone can file an expense. If the expense makes sense for the development of the community, it will be "merged" in the ledger of our open collective by the core contributors and the person who filed the expense will be reimbursed.
+
+
+## Credits
+
+
+### Contributors
+
+Thank you to all the people who have already contributed to buttercup-desktop!
+<a href="graphs/contributors"><img src="https://opencollective.com/buttercup-desktop/contributors.svg?width=890" /></a>
+
+
+### Backers
+
+Thank you to all our backers! [[Become a backer](https://opencollective.com/buttercup-desktop#backer)]
+
+<a href="https://opencollective.com/buttercup-desktop#backers" target="_blank"><img src="https://opencollective.com/buttercup-desktop/backers.svg?width=890"></a>
+
+
+### Sponsors
+
+Thank you to all our sponsors! (please ask your company to also support this open source project by [becoming a sponsor](https://opencollective.com/buttercup-desktop#sponsor))
+
+<a href="https://opencollective.com/buttercup-desktop/sponsor/0/website" target="_blank"><img src="https://opencollective.com/buttercup-desktop/sponsor/0/avatar.svg"></a>
+<a href="https://opencollective.com/buttercup-desktop/sponsor/1/website" target="_blank"><img src="https://opencollective.com/buttercup-desktop/sponsor/1/avatar.svg"></a>
+<a href="https://opencollective.com/buttercup-desktop/sponsor/2/website" target="_blank"><img src="https://opencollective.com/buttercup-desktop/sponsor/2/avatar.svg"></a>
+<a href="https://opencollective.com/buttercup-desktop/sponsor/3/website" target="_blank"><img src="https://opencollective.com/buttercup-desktop/sponsor/3/avatar.svg"></a>
+<a href="https://opencollective.com/buttercup-desktop/sponsor/4/website" target="_blank"><img src="https://opencollective.com/buttercup-desktop/sponsor/4/avatar.svg"></a>
+<a href="https://opencollective.com/buttercup-desktop/sponsor/5/website" target="_blank"><img src="https://opencollective.com/buttercup-desktop/sponsor/5/avatar.svg"></a>
+<a href="https://opencollective.com/buttercup-desktop/sponsor/6/website" target="_blank"><img src="https://opencollective.com/buttercup-desktop/sponsor/6/avatar.svg"></a>
+<a href="https://opencollective.com/buttercup-desktop/sponsor/7/website" target="_blank"><img src="https://opencollective.com/buttercup-desktop/sponsor/7/avatar.svg"></a>
+<a href="https://opencollective.com/buttercup-desktop/sponsor/8/website" target="_blank"><img src="https://opencollective.com/buttercup-desktop/sponsor/8/avatar.svg"></a>
+<a href="https://opencollective.com/buttercup-desktop/sponsor/9/website" target="_blank"><img src="https://opencollective.com/buttercup-desktop/sponsor/9/avatar.svg"></a>

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 > Cross-platform, free and open-source password manager based on NodeJS.
 
-[![Buttercup](https://cdn.rawgit.com/buttercup-pw/buttercup-assets/6582a033/badge/buttercup-slim.svg)](https://buttercup.pw) [![Build Status](https://travis-ci.org/buttercup/buttercup-desktop.svg?branch=master)](https://travis-ci.org/buttercup/buttercup-desktop) [![Build status](https://ci.appveyor.com/api/projects/status/tvthn0hnrsrr4ugy/branch/master?svg=true)](https://ci.appveyor.com/project/sallar/buttercup/branch/master)
+[![Backers on Open Collective](https://opencollective.com/buttercup-desktop/backers/badge.svg)](#backers) [![Sponsors on Open Collective](https://opencollective.com/buttercup-desktop/sponsors/badge.svg)](#sponsors) [![Buttercup](https://cdn.rawgit.com/buttercup-pw/buttercup-assets/6582a033/badge/buttercup-slim.svg)](https://buttercup.pw) [![Build Status](https://travis-ci.org/buttercup/buttercup-desktop.svg?branch=master)](https://travis-ci.org/buttercup/buttercup-desktop) [![Build status](https://ci.appveyor.com/api/projects/status/tvthn0hnrsrr4ugy/branch/master?svg=true)](https://ci.appveyor.com/project/sallar/buttercup/branch/master)
  [![Github All Releases](https://img.shields.io/github/downloads/buttercup-pw/buttercup/total.svg)](https://github.com/buttercup-pw/buttercup/releases) [![encryption](https://img.shields.io/badge/Encryption-AES%20256%20CBC-red.svg)](https://tools.ietf.org/html/rfc3602) [![Gitter](https://img.shields.io/gitter/room/buttercup-cpre/buttercup.svg)](https://gitter.im/buttercup/buttercup)
 
 ![image](https://user-images.githubusercontent.com/768052/29536730-9db58428-86c7-11e7-9bef-418a8cd14830.png)
@@ -102,10 +102,38 @@ $ npm run package:linux
 
 ### Contributions
 
+This project exists thanks to all the people who contribute. [[Contribute]](CONTRIBUTING.md).
+<a href="graphs/contributors"><img src="https://opencollective.com/buttercup-desktop/contributors.svg?width=890" /></a>
+
  * Mohammad Amiri (Brand & Identity) ([@pixelvisualize](https://twitter.com/pixelvisualize))
  * Arash Asghari (Brand & Identity) ([@_arashasghari](https://twitter.com/_arashasghari))
 
 > We welcome contributions. Please read [Contribution Guide](CONTRIBUTING.md) before sending a PR.
+
+
+### Backers
+
+Thank you to all our backers! 🙏 [[Become a backer](https://opencollective.com/buttercup-desktop#backer)]
+
+<a href="https://opencollective.com/buttercup-desktop#backers" target="_blank"><img src="https://opencollective.com/buttercup-desktop/backers.svg?width=890"></a>
+
+
+### Sponsors
+
+Support this project by becoming a sponsor. Your logo will show up here with a link to your website. [[Become a sponsor](https://opencollective.com/buttercup-desktop#sponsor)]
+
+<a href="https://opencollective.com/buttercup-desktop/sponsor/0/website" target="_blank"><img src="https://opencollective.com/buttercup-desktop/sponsor/0/avatar.svg"></a>
+<a href="https://opencollective.com/buttercup-desktop/sponsor/1/website" target="_blank"><img src="https://opencollective.com/buttercup-desktop/sponsor/1/avatar.svg"></a>
+<a href="https://opencollective.com/buttercup-desktop/sponsor/2/website" target="_blank"><img src="https://opencollective.com/buttercup-desktop/sponsor/2/avatar.svg"></a>
+<a href="https://opencollective.com/buttercup-desktop/sponsor/3/website" target="_blank"><img src="https://opencollective.com/buttercup-desktop/sponsor/3/avatar.svg"></a>
+<a href="https://opencollective.com/buttercup-desktop/sponsor/4/website" target="_blank"><img src="https://opencollective.com/buttercup-desktop/sponsor/4/avatar.svg"></a>
+<a href="https://opencollective.com/buttercup-desktop/sponsor/5/website" target="_blank"><img src="https://opencollective.com/buttercup-desktop/sponsor/5/avatar.svg"></a>
+<a href="https://opencollective.com/buttercup-desktop/sponsor/6/website" target="_blank"><img src="https://opencollective.com/buttercup-desktop/sponsor/6/avatar.svg"></a>
+<a href="https://opencollective.com/buttercup-desktop/sponsor/7/website" target="_blank"><img src="https://opencollective.com/buttercup-desktop/sponsor/7/avatar.svg"></a>
+<a href="https://opencollective.com/buttercup-desktop/sponsor/8/website" target="_blank"><img src="https://opencollective.com/buttercup-desktop/sponsor/8/avatar.svg"></a>
+<a href="https://opencollective.com/buttercup-desktop/sponsor/9/website" target="_blank"><img src="https://opencollective.com/buttercup-desktop/sponsor/9/avatar.svg"></a>
+
+
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "package:mac": "build --mac",
     "package:win": "build --win --x64",
     "package": "build --mac --linux --win --x64 -p always",
-    "package:current": "build"
+    "package:current": "build",
+    "postinstall": "opencollective postinstall"
   },
   "lint-staged": {
     "{src,config,test}/**/*.js": [
@@ -106,7 +107,9 @@
     "url": "https://github.com/buttercup/buttercup-desktop/issues"
   },
   "homepage": "https://buttercup.pw",
-  "dependencies": {},
+  "dependencies": {
+    "opencollective": "^1.0.3"
+  },
   "devDependencies": {
     "@buttercup/ui": "^0.6.1",
     "@types/node": "^6.0.45",
@@ -231,5 +234,10 @@
     "webpack": "2.2.0",
     "webpack-dev-server": "2.2.0",
     "webpack-merge": "^2.6.0"
+  },
+  "collective": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/buttercup-desktop",
+    "logo": "https://opencollective.com/opencollective/logo.txt"
   }
 }


### PR DESCRIPTION
This pull request adds backers and sponsors from your Open Collective https://opencollective.com/buttercup-desktop ❤️
  
  It adds two badges at the top to show the latest number of backers and sponsors. It also adds placeholders so that the avatar/logo of new backers/sponsors can automatically be shown without having to update your README.md. [[more info](https://github.com/opencollective/opencollective/wiki/Github-banner)]. See how it looks on [this repo](https://github.com/apex/apex#backers).
We have also added a `postinstall` script to let people know after `npm|yarn install` that you are welcoming donations (optional). [[More info](https://github.com/OpenCollective/opencollective-cli)]
You can also add a "Donate" button to your website and automatically show your backers and sponsors there with our widgets. Have a look here: https://opencollective.com/widgets

  P.S: As with any pull request, feel free to comment or suggest changes. The only thing "required" are the placeholders on the README because we believe it's important to acknowledge the people in your community that are contributing (financially or with code!).

  Thank you for your great contribution to the open source community. You are awesome! 🙌
  And welcome to the open collective community! 😊

  Come chat with us in the #opensource channel on https://slack.opencollective.com - great place to ask questions and share best practices with other open source sustainers!
  