### PR TITLE
Fix root folder context menu

### DIFF
--- a/locales/de.json
+++ b/locales/de.json
@@ -104,5 +104,5 @@
   "open-file-for-importing-error": "Die Importfunktion sollte nicht ausgeführt werden, wenn das Hauptfesnter nicht geöffnet ist.",
   "yes": "Ja",
   "no": "Nein",
-  "custom-fields-title-empty-info": "Du hast vergessen den Titel bei einem oder mehreren benutzerdefinierten Feldern anzugeben."
+  "custom-fields-label-empty-info": "Du hast vergessen den Titel bei einem oder mehreren benutzerdefinierten Feldern anzugeben."
 }

--- a/src/renderer/components/tree-view/index.js
+++ b/src/renderer/components/tree-view/index.js
@@ -101,27 +101,12 @@ class TreeView extends Component {
       const nonRootContextMenu =
         depth > 0
           ? [
-              { type: 'separator' },
               {
                 label: intl.formatMessage({
                   id: 'move-to-root',
                   defaultMessage: 'Move to Root'
                 }),
                 click: () => this.props.onMoveGroup(groupId, null)
-              },
-              {
-                label: intl.formatMessage({
-                  id: 'move-to-group',
-                  defaultMessage: 'Move to Group'
-                }),
-                submenu: createMenuFromGroups(
-                  groups,
-                  groupId,
-                  selectedGroupId => {
-                    this.props.onMoveGroup(groupId, selectedGroupId);
-                  },
-                  false
-                )
               }
             ]
           : [];
@@ -134,7 +119,22 @@ class TreeView extends Component {
           }),
           click: () => this.handleAddClick(null, groupId)
         },
+        { type: 'separator' },
         ...nonRootContextMenu,
+        {
+          label: intl.formatMessage({
+            id: 'move-to-group',
+            defaultMessage: 'Move to Group'
+          }),
+          submenu: createMenuFromGroups(
+            groups,
+            groupId,
+            selectedGroupId => {
+              this.props.onMoveGroup(groupId, selectedGroupId);
+            },
+            false
+          )
+        },
         {
           label: intl.formatMessage({
             id: 'rename',

--- a/src/renderer/components/tree-view/index.js
+++ b/src/renderer/components/tree-view/index.js
@@ -111,6 +111,22 @@ class TreeView extends Component {
             ]
           : [];
 
+      const availableGroups = createMenuFromGroups(
+        groups,
+        groupId,
+        selectedGroupId => {
+          this.props.onMoveGroup(groupId, selectedGroupId);
+        },
+        false
+      );
+
+      const groupsMenu =
+        availableGroups.items.length > 0
+          ? {
+              submenu: availableGroups
+            }
+          : {};
+
       showContextMenu([
         {
           label: intl.formatMessage({
@@ -126,14 +142,8 @@ class TreeView extends Component {
             id: 'move-to-group',
             defaultMessage: 'Move to Group'
           }),
-          submenu: createMenuFromGroups(
-            groups,
-            groupId,
-            selectedGroupId => {
-              this.props.onMoveGroup(groupId, selectedGroupId);
-            },
-            false
-          )
+          enabled: availableGroups.items,
+          ...groupsMenu
         },
         {
           label: intl.formatMessage({

--- a/src/renderer/components/tree-view/index.js
+++ b/src/renderer/components/tree-view/index.js
@@ -81,7 +81,7 @@ class TreeView extends Component {
   }
 
   handleRightClick = (node, groups, e) => {
-    const { id: groupId, isTrash } = node;
+    const { id: groupId, isTrash, depth } = node;
     const { intl } = this.props;
 
     // Prevent righ click from propagation to parent
@@ -98,6 +98,34 @@ class TreeView extends Component {
         }
       ]);
     } else {
+      const nonRootContextMenu =
+        depth > 0
+          ? [
+              { type: 'separator' },
+              {
+                label: intl.formatMessage({
+                  id: 'move-to-root',
+                  defaultMessage: 'Move to Root'
+                }),
+                click: () => this.props.onMoveGroup(groupId, null)
+              },
+              {
+                label: intl.formatMessage({
+                  id: 'move-to-group',
+                  defaultMessage: 'Move to Group'
+                }),
+                submenu: createMenuFromGroups(
+                  groups,
+                  groupId,
+                  selectedGroupId => {
+                    this.props.onMoveGroup(groupId, selectedGroupId);
+                  },
+                  false
+                )
+              }
+            ]
+          : [];
+
       showContextMenu([
         {
           label: intl.formatMessage({
@@ -106,34 +134,13 @@ class TreeView extends Component {
           }),
           click: () => this.handleAddClick(null, groupId)
         },
+        ...nonRootContextMenu,
         {
           label: intl.formatMessage({
             id: 'rename',
             defaultMessage: 'Rename'
           }),
           click: () => this.props.onRenameClick(groupId)
-        },
-        { type: 'separator' },
-        {
-          label: intl.formatMessage({
-            id: 'move-to-root',
-            defaultMessage: 'Move to Root'
-          }),
-          click: () => this.props.onMoveGroup(groupId, null)
-        },
-        {
-          label: intl.formatMessage({
-            id: 'move-to-group',
-            defaultMessage: 'Move to Group'
-          }),
-          submenu: createMenuFromGroups(
-            groups,
-            groupId,
-            selectedGroupId => {
-              this.props.onMoveGroup(groupId, selectedGroupId);
-            },
-            false
-          )
         },
         { type: 'separator' },
         {

--- a/src/shared/selectors.js
+++ b/src/shared/selectors.js
@@ -97,17 +97,19 @@ export const getGroups = createSelector(
     const rest = groups.filter(g => !g.isTrash);
 
     // set depth key in group object
-    const setGroupDepth = (restGroups = rest, depth = 0) =>
-      restGroups.map(group => {
-        return {
-          depth,
-          ...group,
-          groups: setGroupDepth(group.groups, depth + 1)
-        };
-      });
+    const setGroupDepth = (restGroups, depth = 0) =>
+      Array.isArray(restGroups) && restGroups.length > 0
+        ? restGroups.map(group => {
+            return {
+              depth,
+              ...group,
+              groups: setGroupDepth(group.groups, depth + 1)
+            };
+          })
+        : [];
 
     return [
-      ...sortDeepByKey(setGroupDepth(), sortMode, 'groups'),
+      ...sortDeepByKey(setGroupDepth(rest), sortMode, 'groups'),
       ...trashGroups
     ];
   }

--- a/src/shared/selectors.js
+++ b/src/shared/selectors.js
@@ -95,6 +95,20 @@ export const getGroups = createSelector(
   (groups, sortMode) => {
     const trashGroups = groups.filter(g => g.isTrash);
     const rest = groups.filter(g => !g.isTrash);
-    return [...sortDeepByKey(rest, sortMode, 'groups'), ...trashGroups];
+
+    // set depth key in group object
+    const setGroupDepth = (restGroups = rest, depth = 0) =>
+      restGroups.map(group => {
+        return {
+          depth,
+          ...group,
+          groups: setGroupDepth(group.groups, depth + 1)
+        };
+      });
+
+    return [
+      ...sortDeepByKey(setGroupDepth(), sortMode, 'groups'),
+      ...trashGroups
+    ];
   }
 );


### PR DESCRIPTION
This PR fixes #421.

**Reproduce**
- create a root folder
- right click 
- move to root
- disappears

or

- only one root folder exists
- right click
- move to groups is empty
