### PR TITLE
Fix expand bug in tree view

### DIFF
--- a/src/renderer/components/tree-view/index.js
+++ b/src/renderer/components/tree-view/index.js
@@ -245,8 +245,9 @@ class TreeView extends Component {
         <Tree
           draggable
           showLine={false}
-          selectedKeys={this.props.selectedKeys}
           expandedKeys={this.props.expandedKeys}
+          selectedKeys={this.props.selectedKeys}
+          autoExpandParent={false}
           onSelect={this.handleSelect}
           onExpand={this.handleExpand}
           onDrop={this.handleDrop}

--- a/src/shared/actions/groups.js
+++ b/src/shared/actions/groups.js
@@ -76,7 +76,6 @@ export const removeGroup = groupId => (dispatch, getState) => {
   }
 };
 
-// @todo: fix expanded keys
 export const addGroup = parentId => dispatch => {
   dispatch(addExpandedKeys(parentId));
   dispatch(addTemporaryGroup(parentId));


### PR DESCRIPTION
After two redbull and one line of code, I've fixed a bug in the treeview. 

**Reproduce:**
![nov-18-2017 19-02-08](https://user-images.githubusercontent.com/15351728/32983319-058041f4-cc93-11e7-9a68-483ea949b2ef.gif)
