### PR TITLE
Add a snap package (https://snapcraft.io)

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     },
     "linux": {
       "target": [
+        "snap",
         "rpm",
         "AppImage",
         "deb"
@@ -171,7 +172,7 @@
     "devtron": "^1.4.0",
     "dropbox-fs": "^0.0.5",
     "electron": "^1.7.9",
-    "electron-builder": "^19.45.5",
+    "electron-builder": "^19.53.0",
     "electron-debug": "^1.1.0",
     "electron-devtools-installer": "^2.2.0",
     "electron-installer-dmg": "^0.1.2",


### PR DESCRIPTION
Hi! I put together this PR to add a [snap](https://snapcraft.io) package. I've tested it on Ubuntu 17.10 but it should work just as well on Ubuntu 14.04, 16.04, Linux Mint, Manjaro, Debian, OpenSUSE, Solus, etc.

If you merge and `npm run package:linux` it will create `release/buttercup-desktop_0.25.1_amd64.snap`.

Copy this to a Linux system, [enable snap support](https://docs.snapcraft.io/core/install), then run:
`sudo snap install --dangerous buttercup-desktop_0.25.1_amd64.snap`

Run with `buttercup-desktop` or find it in the launcher.

If you create a developer account and push this to the Snap Store, it can be discovered and installed through GNOME Software and https://snapcraft.io/discover. To create the developer account, [sign up here](https://dashboard.snapcraft.io/dev/account/), then [register the "buttercup-desktop" name](https://dashboard.snapcraft.io/register-snap/?name=buttercup-desktop).

You'll need the `snapcraft` command to push the snap file to the store.
* If you're on a Mac, you can `brew install snapcraft`
* If you're on Linux, it's `sudo snap install --classic snapcraft`

Then you can push Buttercup Desktop out with:
`snapcraft push buttercup-desktop_0.25.1_amd64.snap --release stable`

(You can also push to the Snap Store [programatically from Travis](https://docs.snapcraft.io/build-snaps/ci-integration#using-travis).)
  
  
  
  