### PR TITLE
Ignore case in sort methods

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "clean": "rimraf ./app/node_modules",
     "format": "prettier --write '{src,config,test,locales}/**/*.{js,json}'",
     "precommit": "lint-staged",
-    "test": "cross-env NODE_ENV=test ava && npm run lint",
+    "test": "npm run test:unit && npm run test:gui && npm run lint",
+    "test:gui": "npm run build && cross-env NODE_ENV=test ava test/gui/**",
+    "test:unit": "cross-env NODE_ENV=test ava test/unit/**",
     "lint": "eslint ./src ./config",
     "build:main": "cross-env NODE_ENV=production webpack --config ./config/webpack.config.electron --progress --colors",
     "build:renderer": "cross-env NODE_ENV=production webpack --config ./config/webpack.config.production --progress --colors",
@@ -95,8 +97,7 @@
   ],
   "ava": {
     "files": [
-      "test/**/*.js",
-      "**/test/**/*.js"
+      "test/**/*.js"
     ],
     "source": [
       "src/**/*.{js,jsx}"

--- a/package.json
+++ b/package.json
@@ -95,7 +95,8 @@
   ],
   "ava": {
     "files": [
-      "test/**/*.js"
+      "test/**/*.js",
+      "**/test/**/*.js"
     ],
     "source": [
       "src/**/*.{js,jsx}"

--- a/src/shared/utils/collection.js
+++ b/src/shared/utils/collection.js
@@ -18,7 +18,7 @@ export function sortByKey(list, sortKey) {
   if (!key || !order) {
     return list;
   }
-  const sorted = sortBy(list, o => at(o, key));
+  const sorted = sortBy(list, o => at(o, key).map(item => item.toLowerCase()));
   return order === 'asc' ? sorted : sorted.reverse();
 }
 

--- a/src/shared/utils/test/collection.js
+++ b/src/shared/utils/test/collection.js
@@ -1,0 +1,67 @@
+import test from 'ava';
+import { sortByKey } from '../collection';
+
+test('sortByKey should do nothing when sortKey is invalid', t => {
+  const unsortedInput = [{ name: 'Yellow' }, { name: 'Blue' }, { name: 'Red' }];
+
+  const outputWithoutKey = sortByKey(unsortedInput, '-asc');
+  t.deepEqual(
+    outputWithoutKey,
+    unsortedInput,
+    'sortKey should do nothing when key is not provided'
+  );
+
+  const outputWithoutOrder = sortByKey(unsortedInput, 'name-');
+  t.deepEqual(
+    outputWithoutOrder,
+    unsortedInput,
+    'sortKey should do nothing when order is not provided'
+  );
+});
+
+test('sortByKey should sort items based on the given key and order', t => {
+  const unsortedInput = [
+    { name: 'Yellow' },
+    { name: 'Blue' },
+    { name: 'Red' },
+    { name: 'green' }
+  ];
+
+  const cases = [
+    {
+      sortKey: 'name-asc',
+      message: 'sortKey should sort items ascending, when order is asc',
+      expectedOutput: [
+        { name: 'Blue' },
+        { name: 'green' },
+        { name: 'Red' },
+        { name: 'Yellow' }
+      ]
+    },
+    {
+      sortKey: 'name-dsc',
+      message: 'sortKey should sort items in descending, when order is dsc',
+      expectedOutput: [
+        { name: 'Yellow' },
+        { name: 'Red' },
+        { name: 'green' },
+        { name: 'Blue' }
+      ]
+    },
+    {
+      sortKey: 'name-something',
+      message: 'sortKey should sort items in descending, when order is not asc',
+      expectedOutput: [
+        { name: 'Yellow' },
+        { name: 'Red' },
+        { name: 'green' },
+        { name: 'Blue' }
+      ]
+    }
+  ];
+
+  cases.forEach(testCase => {
+    const output = sortByKey(unsortedInput, testCase.sortKey);
+    t.deepEqual(output, testCase.expectedOutput, testCase.message);
+  });
+});

--- a/test/gui/app.js
+++ b/test/gui/app.js
@@ -1,6 +1,6 @@
 import path from 'path';
 import test from 'ava';
-import { ArchiveTypes } from '../src/shared/buttercup/types';
+import { ArchiveTypes } from '../../src/shared/buttercup/types';
 import { Application } from 'spectron';
 
 // method to wait n ms
@@ -14,7 +14,7 @@ let inputs;
 test.before(async t => {
   app = new Application({
     path: require('electron'),
-    args: [path.join(__dirname, '../app')]
+    args: [path.join(__dirname, '../../app')]
   });
 
   await app.start();

--- a/test/unit/collection.js
+++ b/test/unit/collection.js
@@ -1,5 +1,5 @@
 import test from 'ava';
-import { sortByKey } from '../collection';
+import { sortByKey } from '../../src/shared/utils/collection';
 
 test('sortByKey should do nothing when sortKey is invalid', t => {
   const unsortedInput = [{ name: 'Yellow' }, { name: 'Blue' }, { name: 'Red' }];

--- a/test/unit/collection.js
+++ b/test/unit/collection.js
@@ -1,24 +1,6 @@
 import test from 'ava';
 import { sortByKey } from '../../src/shared/utils/collection';
 
-test('sortByKey should do nothing when sortKey is invalid', t => {
-  const unsortedInput = [{ name: 'Yellow' }, { name: 'Blue' }, { name: 'Red' }];
-
-  const outputWithoutKey = sortByKey(unsortedInput, '-asc');
-  t.deepEqual(
-    outputWithoutKey,
-    unsortedInput,
-    'sortKey should do nothing when key is not provided'
-  );
-
-  const outputWithoutOrder = sortByKey(unsortedInput, 'name-');
-  t.deepEqual(
-    outputWithoutOrder,
-    unsortedInput,
-    'sortKey should do nothing when order is not provided'
-  );
-});
-
 test('sortByKey should sort items based on the given key and order', t => {
   const unsortedInput = [
     { name: 'Yellow' },
@@ -29,8 +11,18 @@ test('sortByKey should sort items based on the given key and order', t => {
 
   const cases = [
     {
+      sortKey: '-asc',
+      message: 'should do nothing when key is not provided',
+      expectedOutput: unsortedInput
+    },
+    {
+      sortKey: 'name-',
+      message: 'should do nothing when order is not provided',
+      expectedOutput: unsortedInput
+    },
+    {
       sortKey: 'name-asc',
-      message: 'sortKey should sort items ascending, when order is asc',
+      message: 'should sort items ascending, when order is asc',
       expectedOutput: [
         { name: 'Blue' },
         { name: 'green' },
@@ -40,7 +32,7 @@ test('sortByKey should sort items based on the given key and order', t => {
     },
     {
       sortKey: 'name-dsc',
-      message: 'sortKey should sort items in descending, when order is dsc',
+      message: 'should sort items in descending, when order is dsc',
       expectedOutput: [
         { name: 'Yellow' },
         { name: 'Red' },
@@ -50,7 +42,7 @@ test('sortByKey should sort items based on the given key and order', t => {
     },
     {
       sortKey: 'name-something',
-      message: 'sortKey should sort items in descending, when order is not asc',
+      message: 'should sort items in descending, when order is not asc',
       expectedOutput: [
         { name: 'Yellow' },
         { name: 'Red' },


### PR DESCRIPTION
This pull request contains the following change:

- Ignoring case when sorting items(+ tests for this change)

I wasn’t sure that where should I put unit tests for this method, so I have made a minor change in **ava** settings and put tests for this method under its parent folder. Please let me know if any changes required, especially in tests.

--
Fixes #476