### PR TITLE
Added shortcut to lock current archive

### DIFF
--- a/src/renderer/components/sidebar-item.js
+++ b/src/renderer/components/sidebar-item.js
@@ -136,6 +136,7 @@ class SidebarItem extends PureComponent {
         ? [
             {
               label: label('lock'),
+              accelerator: `CmdOrCtrl+l`,
               click: this.props.onLockArchive
             },
             {

--- a/src/renderer/components/sidebar-item.js
+++ b/src/renderer/components/sidebar-item.js
@@ -136,7 +136,7 @@ class SidebarItem extends PureComponent {
         ? [
             {
               label: label('lock'),
-              accelerator: `CmdOrCtrl+l`,
+              accelerator: this.props.active ? 'CmdOrCtrl+l' : null,
               click: this.props.onLockArchive
             },
             {

--- a/src/renderer/system/shortcuts.js
+++ b/src/renderer/system/shortcuts.js
@@ -1,8 +1,8 @@
 import Mousetrap from 'mousetrap';
 import ms from 'ms';
-import { getCurrentEntry } from '../../shared/selectors';
+import { getCurrentArchiveId, getCurrentEntry } from '../../shared/selectors';
 import { copyToClipboard, readClipboard } from './utils';
-
+import { lockArchive } from './../../shared/actions/archives';
 const __cache = {
   timer: null
 };
@@ -40,6 +40,16 @@ export const setupShortcuts = store => {
     const currentEntry = getCurrentEntry(store.getState());
     if (currentEntry) {
       copyToClipboard(currentEntry.properties.username);
+    }
+  });
+
+  /**
+   * Lock Current Archive 
+   */
+  Mousetrap.bind('mod+l', () => {
+    const currentArchiveId = getCurrentArchiveId(store.getState());
+    if (currentArchiveId) {
+      store.dispatch(lockArchive(currentArchiveId));
     }
   });
 };

--- a/src/renderer/system/shortcuts.js
+++ b/src/renderer/system/shortcuts.js
@@ -1,8 +1,8 @@
 import Mousetrap from 'mousetrap';
 import ms from 'ms';
+import { lockArchive } from '../../shared/actions/archives';
 import { getCurrentArchiveId, getCurrentEntry } from '../../shared/selectors';
 import { copyToClipboard, readClipboard } from './utils';
-import { lockArchive } from './../../shared/actions/archives';
 const __cache = {
   timer: null
 };


### PR DESCRIPTION
A user can now hit `Ctrl+l` on windows/linux or `Command+l` on Mac to lock the current archive. 

Fixes #470 