### PR TITLE
Nicer frame for high sierra

### DIFF
--- a/src/main/windows.js
+++ b/src/main/windows.js
@@ -1,6 +1,6 @@
 import { app, BrowserWindow, ipcMain as ipc } from 'electron';
 import debounce from 'lodash/debounce';
-import { isHighSierra } from '../shared/utils/platform';
+import { isHighSierra, isOSX } from '../shared/utils/platform';
 import { getWindowManager } from './lib/window-manager';
 import { getSetting } from '../shared/selectors';
 import { getPathToFile } from './lib/utils';
@@ -20,8 +20,10 @@ export function setupWindows(store) {
       minWidth: 680,
       minHeight: 500,
       title: app.getName(),
+      titleBarStyle: isOSX() && 'hiddenInset',
       // Temporary fix for High Sierra. See #339
-      titleBarStyle: isHighSierra() ? null : 'hiddenInset',
+      frame: !isOSX(),
+      transparent: isOSX() && isHighSierra(),
       show: process.env.NODE_ENV === 'development',
       darkTheme: true,
       vibrancy: 'ultra-dark'

--- a/src/renderer/components/sidebar.js
+++ b/src/renderer/components/sidebar.js
@@ -1,14 +1,11 @@
 import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
 import styled from 'styled-components';
-import { isOSX, isHighSierra } from '../../shared/utils/platform';
+import { isOSX } from '../../shared/utils/platform';
 import AddArchiveButton from '../containers/add-archive-button';
 import EmptyView from './empty-view';
 import BaseColumn from './column';
 import SidebarItem from './sidebar-item';
-
-// Temporary fix for High Sierra. See #339
-const usesBigPadding = isOSX() && !isHighSierra();
 
 const Column = styled(BaseColumn)`
   width: ${props =>
@@ -21,10 +18,7 @@ const Column = styled(BaseColumn)`
 `;
 
 const ArchiveList = styled.ul`
-  margin: ${usesBigPadding
-      ? 'calc(var(--spacing-one) * 3)'
-      : 'var(--spacing-one)'}
-    0 0 0;
+  margin: calc(var(--spacing-one) * ${isOSX() ? 3 : 1}) 0 0 0;
   padding: 0;
 `;
 


### PR DESCRIPTION
Instead of having the title bar on macOS High Sierra (due to #339), we're opting for having the title bar but instead having no rounded corners.

<img width="1182" alt="image" src="https://user-images.githubusercontent.com/768052/36052376-200e77d0-0df6-11e8-9767-fd586bdc535c.png">
