### PR TITLE
Sidebar Icons Improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -261,6 +261,7 @@
     "styled-components": "^3.1.6",
     "styled-flexbox": "^0.2.0",
     "sweetalert2": "^6.6.0",
+    "tinycolor2": "^1.4.1",
     "tmp": "0.0.33",
     "uglifyjs-webpack-plugin": "^1.0.1",
     "url-loader": "^0.5.7",

--- a/src/renderer/components/sidebar-item.js
+++ b/src/renderer/components/sidebar-item.js
@@ -225,13 +225,12 @@ class SidebarItem extends PureComponent {
             this.avatarRef = ref;
           }}
         >
-          <span>{briefName}</span>
-          {condenced &&
-            brands[type].remote && (
-              <Icon>
-                <img src={brands[type].icon} alt={brands[type].name} />
-              </Icon>
-            )}
+          {condenced && locked ? <LockClosed /> : <span>{briefName}</span>}
+          <If condition={condenced && brands[type].remote}>
+            <Icon>
+              <img src={brands[type].icon} alt={brands[type].name} />
+            </Icon>
+          </If>
           <If condition={this.state.isPickerOpen}>
             <PortalWithState
               closeOnEsc
@@ -253,7 +252,7 @@ class SidebarItem extends PureComponent {
             </PortalWithState>
           </If>
         </Avatar>
-        {!condenced && (
+        <If condition={!condenced}>
           <section>
             <div>{formattedName}</div>
             <span className="status">
@@ -261,7 +260,7 @@ class SidebarItem extends PureComponent {
               {brands[type].name}
             </span>
           </section>
-        )}
+        </If>
       </Wrapper>
     );
   }

--- a/src/renderer/components/sidebar-item.js
+++ b/src/renderer/components/sidebar-item.js
@@ -7,6 +7,7 @@ import LockClosed from 'react-icons/lib/md/lock-outline';
 import { GithubPicker } from 'react-color';
 import { PortalWithState } from 'react-portal';
 import { translate } from 'react-i18next';
+import tinycolor from 'tinycolor2';
 import { brands } from '../../shared/buttercup/brands';
 import { ImportTypeInfo } from '../../shared/buttercup/types';
 import { showContextMenu } from '../system/menu';
@@ -57,6 +58,7 @@ const Avatar = styled.div`
   border-radius: 50px;
   border: 2px solid rgba(255, 255, 255, 0.2);
   background-color: ${props => props.color};
+  color: ${props => (tinycolor(props.color).isLight() ? '#222' : '#fff')};
   font-weight: 400;
   font-size: 1rem;
   display: flex;

--- a/src/renderer/components/sidebar-item.js
+++ b/src/renderer/components/sidebar-item.js
@@ -66,10 +66,17 @@ const Avatar = styled.div`
   justify-content: center;
   position: relative;
 
-  &:hover {
-    .cog {
-      display: block;
-    }
+  &:after {
+    content: '';
+    display: ${props => (props.locked ? 'none' : 'block')};
+    width: 4px;
+    height: 4px;
+    border-radius: 50%;
+    background-color: rgba(255, 255, 255, 0.8);
+    position: absolute;
+    left: -10px;
+    top: 50%;
+    margin-top: -2px;
   }
 `;
 
@@ -221,11 +228,12 @@ class SidebarItem extends PureComponent {
       >
         <Avatar
           color={color || '#000000'}
+          locked={locked}
           innerRef={ref => {
             this.avatarRef = ref;
           }}
         >
-          {condenced && locked ? <LockClosed /> : <span>{briefName}</span>}
+          <span>{briefName}</span>
           <If condition={condenced && brands[type].remote}>
             <Icon>
               <img src={brands[type].icon} alt={brands[type].name} />

--- a/src/renderer/components/sidebar-item.js
+++ b/src/renderer/components/sidebar-item.js
@@ -4,13 +4,33 @@ import styled from 'styled-components';
 import capitalize from 'lodash/capitalize';
 import LockOpen from 'react-icons/lib/md/lock-open';
 import LockClosed from 'react-icons/lib/md/lock-outline';
-import { GithubPicker } from 'react-color';
+import { TwitterPicker } from 'react-color';
 import { PortalWithState } from 'react-portal';
 import { translate } from 'react-i18next';
 import tinycolor from 'tinycolor2';
 import { brands } from '../../shared/buttercup/brands';
 import { ImportTypeInfo } from '../../shared/buttercup/types';
 import { showContextMenu } from '../system/menu';
+
+const COLORS = [
+  '#B80000',
+  '#DB3E00',
+  '#EB144C',
+  '#FF6900',
+  '#FCB900',
+  '#DCE775',
+  '#808900',
+  '#00D084',
+  '#006B76',
+  '#ABB8C3',
+  '#0693E3',
+  '#1273DE',
+  '#004DCF',
+  '#5300EB',
+  '#3F51B5',
+  '#7B64FF',
+  '#9900EF'
+];
 
 const Wrapper = styled.li`
   display: flex;
@@ -249,8 +269,8 @@ class SidebarItem extends PureComponent {
               {({ portal }) => [
                 portal(
                   <PickerWrapper left={this.state.left} top={this.state.top}>
-                    <GithubPicker
-                      width={212}
+                    <TwitterPicker
+                      colors={COLORS}
                       triangle="top-left"
                       onChange={this.handleColorChange}
                     />

--- a/src/renderer/components/sidebar-item.js
+++ b/src/renderer/components/sidebar-item.js
@@ -194,7 +194,8 @@ class SidebarItem extends PureComponent {
     this.setState({ isPickerOpen: false });
   };
 
-  handleColorChange = color => {
+  handleColorChange = (color, e) => {
+    e.stopPropagation();
     this.props.onArchiveUpdate({
       ...this.props.archive,
       color: color.hex


### PR DESCRIPTION
+ When trying to change the color of a locked archive, clicking on the color square caused the "click" event for the sidebar item to fire and unlock process to start.
+ Fix color contrast for light avatar items
+ Add lock state for locked items in condensed mode
+ Better color popover with custom colors
Fixes #325

<img width="1235" alt="screen shot 2018-02-11 at 16 10 25" src="https://user-images.githubusercontent.com/768052/36074528-9ce2b812-0f49-11e8-8bf3-9b976d9d6f83.png">
