### PR TITLE
Remember screen position (#535)

### DIFF
--- a/src/main/windows.js
+++ b/src/main/windows.js
@@ -15,6 +15,8 @@ export function setupWindows(store) {
   // Intro Screen
   windowManager.setBuildProcedure('main', callback => {
     const [width, height] = config.get('window.size', [950, 700]);
+    const windowPosition = config.get('window.position');
+
     // Create the browser window.
     const win = new BrowserWindow({
       width,
@@ -30,6 +32,20 @@ export function setupWindows(store) {
       darkTheme: true,
       vibrancy: 'ultra-dark'
     });
+
+    // set window position only if config exists
+    if (windowPosition) {
+      const [x, y] = windowPosition;
+      win.setPosition(x, y);
+    }
+
+    // set current window position
+    win.on(
+      'move',
+      debounce(() => {
+        config.set('window.position', win.getPosition());
+      }, 500)
+    );
 
     // Set initial menu bar visibility
     const menubarAutoHide = getSetting(store.getState(), 'menubarAutoHide');


### PR DESCRIPTION
**Problem**
Buttercup does not remember the last window position.
This PR should fix it.

I've tested this feature only on macos.

**Issue**
Fixes #535