### PR TITLE
Add a .desktop file

### DIFF
--- a/build/buttercup-desktop.desktop
+++ b/build/buttercup-desktop.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Version=1.1
+Name=Buttercup
+Comment=Javascript Password Vault
+Exec=buttercup
+Icon=buttercup
+Terminal=false
+Type=Application
+Categories=Utility;


### PR DESCRIPTION
This is a .desktop file that follows the [freedesktop](https://www.freedesktop.org) standard for a desktop menu to launch Buttercup.
It can be installed on Linux (and I assume macOS?) into `/usr/share/applications/`

---

I've been using this for a while in the AUR PKGBUILD, but I figured it would be good to have it upstream for any non-AUR users.

---

Note that the icon name is just `buttercup`, which would normally be the [badge](https://github.com/buttercup/buttercup-desktop/blob/master/build/badge.svg) installed as `/usr/share/icons/hicolor/scalable/apps/buttercup.svg`

I'm unsure if you would want me to create that file or not, but I currently do a rename upon install in the AUR PKGBUILD.