### PR TITLE
fix(strings): before-quit log typo

### DIFF
--- a/src/main/app.js
+++ b/src/main/app.js
@@ -167,7 +167,7 @@ app.on('activate', () => {
 });
 
 app.once('before-quit', e => {
-  log.info('Running before-quit operatios.');
+  log.info('Running before-quit operation.');
   const channel = getQueue().channel('saves');
   appTriedToQuit = true;
 


### PR DESCRIPTION
"operatios" v. operation ("operatios" sounds dope in pseudo-Latin though!)