### PR TITLE
feat: prevent loss of an unsaved entry.

### DIFF
--- a/locales/en/base.json
+++ b/locales/en/base.json
@@ -150,7 +150,8 @@
     "custom-fields-label-empty-info": "You've forgotten to set a label for one or more custom fields.",
     "are-you-sure-question": "Are you sure?",
     "displaying-entries": "Displaying {{count}} entries",
-    "no-value": "No Value"
+    "no-value": "No Value",
+    "quit-unsave-entry": "You will lost your entry, are you sure ?"
   },
   "entry-menu": {
     "copy-to-clipboard": "Copy To Clipboard",

--- a/locales/fr/base.json
+++ b/locales/fr/base.json
@@ -150,7 +150,8 @@
     "custom-fields-label-empty-info": "Vous avez oublié de définir un label pour un ou plusieurs champs personnalisés.",
     "are-you-sure-question": "Confirmez-vous ?",
     "displaying-entries": "{{count}} entrées affichées",
-    "no-value": "Vide"
+    "no-value": "Vide",
+    "quit-unsave-entry": "Vous allez perdre vos modifications, voulez-vous continuer ?"
   },
   "entry-menu": {
     "copy-to-clipboard": "Copier dans le presse-papier",

--- a/src/shared/actions/entries.js
+++ b/src/shared/actions/entries.js
@@ -2,7 +2,13 @@ import { createAction } from 'redux-actions';
 import * as entryTools from '../buttercup/entries';
 import { showDialog, showConfirmDialog } from '../../renderer/system/dialog';
 import { getQueue } from '../../renderer/system/queue';
-import { getCurrentGroupId, getCurrentArchiveId } from '../selectors';
+import {
+  getCurrentGroupId,
+  getCurrentArchiveId,
+  getCurrentEntry,
+  getCurrentEntryMode,
+  getEditFormElement
+} from '../selectors';
 import i18n from '../i18n';
 import { EntryFinder } from 'buttercup/dist/buttercup-web.min';
 import { getSharedArchiveManager } from '../buttercup/archive';
@@ -20,7 +26,28 @@ import {
 import { loadOrUnlockArchive } from '../../shared/actions/archives';
 import { loadGroup } from '../../shared/actions/groups';
 
-export const selectEntry = createAction(ENTRIES_SELECTED);
+export const selectEntry = (entryId, isSavingNewEntry = false) => async (
+  dispatch,
+  getState
+) => {
+  try {
+    const currentEntry = getCurrentEntry(getState());
+    const currentEntryMode = getCurrentEntryMode(getState());
+    !currentEntry && currentEntryMode === 'new' && !isSavingNewEntry
+      ? showConfirmDialog(
+          i18n.t('entry.quit-unsave-entry'),
+          choice =>
+            choice === 0
+              ? dispatch({ type: ENTRIES_SELECTED, payload: entryId })
+              : null
+        )
+      : dispatch({ type: ENTRIES_SELECTED, payload: entryId });
+  } catch (err) {
+    console.error(err);
+    showDialog(err);
+  }
+};
+
 export const setSortMode = createAction(ENTRIES_SET_SORT);
 
 export const changeMode = mode => () => ({
@@ -81,7 +108,7 @@ export const newEntry = newValues => async (dispatch, getState) => {
       type: ENTRIES_CREATE,
       payload: entryObj
     });
-    dispatch(selectEntry(entryObj.id));
+    dispatch(selectEntry(entryObj.id, true));
 
     // Then update the entry icon - might be slower, so we don't want the UI to wait for this
     dispatch(fetchEntryIconsAndUpdate(archiveId, [entryObj]));

--- a/src/shared/actions/entries.js
+++ b/src/shared/actions/entries.js
@@ -7,7 +7,6 @@ import {
   getCurrentArchiveId,
   getCurrentEntry,
   getCurrentEntryMode,
-  getEditFormElement,
   getExpandedKeys
 } from '../selectors';
 import i18n from '../i18n';

--- a/src/shared/selectors.js
+++ b/src/shared/selectors.js
@@ -37,6 +37,7 @@ export const getExpandedKeys = createSelector(
 
 export const getAllEntries = state => state.entries.byId;
 export const getCurrentEntryId = state => state.entries.currentEntry;
+export const getCurrentEntryMode = state => state.entries.mode;
 
 export const getCurrentEntry = createSelector(
   getAllEntries,


### PR DESCRIPTION
When creating a new entry, if a user click on an another entry to view
it, ask to him to confirm his action to prevent a data loss.

Update the onClick event on a list element (entries-list) to
be able to check the state of the app and display the dialog window
if it is needed. Create a redux selector to retrieve the mode field
to be able to check into the list if a new entry is opened.

Fixes: https://github.com/buttercup/buttercup-desktop/issues/634