### PR TITLE
Add a snap for Linux

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     },
     "linux": {
       "target": [
+        "snap",
         "rpm",
         "AppImage",
         "deb"


### PR DESCRIPTION
I built and tested a snap package of Buttercup, and it works without issue on Ubuntu 16.04 (and probably on all the distros that have [support support](https://docs.snapcraft.io/installing-snapd/6735)). If you're willing to publish this, it can be featured to Linux users installing apps from the Snap Store. You just need to [create an account](https://snapcraft.io/snaps) and then [register the Buttercup name](https://snapcraft.io/register-snap).

The .snap created by `npx build -l snap` can be released to the Snap Store with `snap push --release stable *.snap`. You'll want to first install snapcraft (`brew install snapcraft`, `snap install snapcraft`, or `apt install snapcraft`) and login (`snapcraft login`).

Cheers!

Fixes #823
Fixes #647 