### PR TITLE
Fix shortcuts  and prevents errors when pressing cmd+b

### DIFF
--- a/src/renderer/system/shortcuts.js
+++ b/src/renderer/system/shortcuts.js
@@ -44,15 +44,17 @@ export const setupShortcuts = store => {
    */
   Mousetrap.bind('mod+b', () => {
     const currentEntry = getCurrentEntry(store.getState());
-    const username = getFacadeFieldValue(currentEntry, 'username');
+    if (currentEntry) {
+      const username = getFacadeFieldValue(currentEntry, 'username');
 
-    if (username) {
-      copyToClipboard(username);
+      if (username) {
+        copyToClipboard(username);
+      }
     }
   });
 
   /**
-   * Lock Current Archive 
+   * Lock Current Archive
    */
   Mousetrap.bind('mod+l', () => {
     const currentArchiveId = getCurrentArchiveId(store.getState());


### PR DESCRIPTION
Hi! I've found a small error. This PR will fix it.

**Reproduce:**
- Start Buttercup
- Don't login to archive and do not select an entry
- Press CMD+B

**Screenshot:**
![screenshot 2018-11-24 at 15 02 37](https://user-images.githubusercontent.com/15351728/48969112-2bc51980-effa-11e8-82b5-b0ad6f3d22f0.png)