### PR TITLE
Fix error message for webdav connection error

### DIFF
--- a/src/renderer/components/file-manager/sources/webdav.js
+++ b/src/renderer/components/file-manager/sources/webdav.js
@@ -96,7 +96,8 @@ class Webdav extends PureComponent {
         console.error(err);
         showDialog(
           t('error.webdav-connection-failed-info', {
-            endpoint
+            endpoint,
+            interpolation: { escapeValue: false }
           })
         );
       });


### PR DESCRIPTION
Unescaped it according to [react-i18next docs](https://www.i18next.com/translation-function/interpolation#unescape).

The docs also mention
> Warning: If you toggle escaping off, you should escape any user input yourself!

Is this necessary in this case? And if so, how would we do that?

closes #728