### PR TITLE
Make it easier to toggle generator

### DIFF
--- a/src/renderer/components/archive/entry-input.js
+++ b/src/renderer/components/archive/entry-input.js
@@ -104,8 +104,11 @@ export default class Input extends PureComponent {
                 isOpen={this.state.isGeneratorOpen}
                 preferPlace="below"
               >
-                <GeneratorToggle active={this.state.isGeneratorOpen}>
-                  <MagicIcon onClick={() => this.handleGeneratorToggle()} />
+                <GeneratorToggle
+                  active={this.state.isGeneratorOpen}
+                  onClick={() => this.handleGeneratorToggle()}
+                >
+                  <MagicIcon />
                 </GeneratorToggle>
               </Generator>
               <Meter input={value} />


### PR DESCRIPTION
Right now it is really hard to toggle the password generator. You have to click the black part of the icon (not even the white background works). 

With this change, it is easier to toggle, since clicking the whole square will toggle the generator.