### PR TITLE
Feature: Warn before losing unsaved entry (edit mode)

### DIFF
--- a/src/shared/actions/entries.js
+++ b/src/shared/actions/entries.js
@@ -6,7 +6,6 @@ import { getQueue } from '../../renderer/system/queue';
 import {
   getCurrentGroupId,
   getCurrentArchiveId,
-  getCurrentEntry,
   getCurrentEntryMode,
   getExpandedKeys
 } from '../selectors';
@@ -26,14 +25,10 @@ import { setExpandedKeys } from '../../shared/actions/ui';
 import { loadOrUnlockArchive } from '../../shared/actions/archives';
 import { loadGroup } from '../../shared/actions/groups';
 
-export const selectEntry = (entryId, isSavingNewEntry = false) => async (
-  dispatch,
-  getState
-) => {
+export const selectEntry = entryId => async (dispatch, getState) => {
   try {
-    const currentEntry = getCurrentEntry(getState());
     const currentEntryMode = getCurrentEntryMode(getState());
-    !currentEntry && currentEntryMode === 'new' && !isSavingNewEntry
+    currentEntryMode === 'new' || currentEntryMode === 'edit'
       ? showConfirmDialog(
           i18n.t('entry.quit-unsave-entry'),
           choice =>
@@ -41,7 +36,10 @@ export const selectEntry = (entryId, isSavingNewEntry = false) => async (
               ? dispatch({ type: ENTRIES_SELECTED, payload: entryId })
               : null
         )
-      : dispatch({ type: ENTRIES_SELECTED, payload: entryId });
+      : dispatch({
+          type: ENTRIES_SELECTED,
+          payload: entryId
+        });
   } catch (err) {
     console.error(err);
     showDialog(err);


### PR DESCRIPTION
Fixes #735 Now when clicking somewhere else during edit mode it will warn you of losing unsaved work. 

notes: I refactored some of the previous code because some of it seemed unnecessary like the parameter `isSavingNewEntry` which is always false and no code toggles it. I didn't understand the currentEntry check; I think checking the currentEntryMode will suffice. 