### PR TITLE
Issue626:  Users password is now cleared from the clipboard after a short duration

### DIFF
--- a/src/renderer/components/archive/copyable.js
+++ b/src/renderer/components/archive/copyable.js
@@ -96,8 +96,8 @@ class Copyable extends PureComponent {
     this.setState({ concealed: !this.state.concealed });
   }
 
-  handleCopy() {
-    copyToClipboard(this.props.children);
+  handleCopy(isSecret) {
+    copyToClipboard(this.props.children, isSecret);
   }
 
   renderPassword(content) {
@@ -141,7 +141,7 @@ class Copyable extends PureComponent {
             <Button
               icon={<CopyIcon />}
               title={t('copyable.copy')}
-              onClick={() => this.handleCopy()}
+              onClick={() => this.handleCopy(isSecret)}
             />
           </HiddenButtonRow>
         </If>

--- a/src/renderer/system/utils.js
+++ b/src/renderer/system/utils.js
@@ -8,16 +8,20 @@ const __cache = {
 
 const currentWindow = remote.getCurrentWindow();
 
-export function copyToClipboard(text) {
+export function copyToClipboard(text, isPassword) {
   clipboard.writeText(text);
 
-  // Clean the clipboard after 15s
-  // @TODO: Make a UI for this.
-  __cache.timer = setTimeout(function clipboardPurgerClosure() {
-    if (readClipboard() === text) {
-      copyToClipboard('');
+  // isPassword is a boolean
+  if (isPassword) {
+    if (__cache.timer) {
+      clearTimeout(__cache.timer);
     }
-  }, ms('15s'));
+
+    // Clean the clipboard after 15s if selection is blank
+    __cache.timer = setTimeout(function clipboardPurgerClosure() {
+      clipboard.writeText('');
+    }, ms('15s'));
+  }
 }
 
 export function readClipboard() {

--- a/src/renderer/system/utils.js
+++ b/src/renderer/system/utils.js
@@ -1,10 +1,23 @@
 import path from 'path';
 import { clipboard, remote, shell } from 'electron';
+import ms from 'ms';
+
+const __cache = {
+  timer: null
+};
 
 const currentWindow = remote.getCurrentWindow();
 
 export function copyToClipboard(text) {
   clipboard.writeText(text);
+
+  // Clean the clipboard after 15s
+  // @TODO: Make a UI for this.
+  __cache.timer = setTimeout(function clipboardPurgerClosure() {
+    if (readClipboard() === text) {
+      copyToClipboard('');
+    }
+  }, ms('15s'));
 }
 
 export function readClipboard() {


### PR DESCRIPTION
Before:
Password was being cleared for clipboard when user would enter ctrl-c, but not when the user pressed the button right of the password.

Now:
Password is cleared from the clipboard for both scenarios. 
