### PR TITLE
Added validation for duplicate labels

### DIFF
--- a/locales/en/base.json
+++ b/locales/en/base.json
@@ -156,7 +156,7 @@
     "displaying-entries": "Displaying {{count}} entries",
     "no-value": "No Value",
     "quit-unsave-entry": "You will lose your changes, are you sure?",
-    "duplicate-label-found": "Duplicate label found for custom fields. Please check your custom fields and make labels unique."
+    "duplicate-label-found": "Duplicate custom fields: Please check your custom fields and rename/remove duplicate labels."
   },
   "entry-menu": {
     "copy-to-clipboard": "Copy To Clipboard",

--- a/locales/en/base.json
+++ b/locales/en/base.json
@@ -155,7 +155,8 @@
     "are-you-sure-question": "Are you sure?",
     "displaying-entries": "Displaying {{count}} entries",
     "no-value": "No Value",
-    "quit-unsave-entry": "You will lose your changes, are you sure?"
+    "quit-unsave-entry": "You will lose your changes, are you sure?",
+    "duplicate-label-found": "Duplicate label found for custom fields. Please check your custom fields and make labels unique."
   },
   "entry-menu": {
     "copy-to-clipboard": "Copy To Clipboard",

--- a/src/shared/buttercup/entries.js
+++ b/src/shared/buttercup/entries.js
@@ -57,6 +57,18 @@ export function validateEntry(entry) {
     if (fields.filter(field => !field.property).length > 0) {
       errorMessages.push(i18n.t('entry.custom-fields-label-empty-info'));
     }
+
+    if (fields.length > 3) {
+      var titleofFields = [];
+
+      for (var i = 3; i < fields.length; i++) {
+        titleofFields.push(fields[i].property);
+      }
+
+      if (titleofFields.length !== new Set(titleofFields).size) {
+        errorMessages.push(i18n.t('entry.duplicate-label-found'));
+      }
+    }
   }
 
   if (errorMessages.length > 0) {


### PR DESCRIPTION
Fixes issue #717

Before:
If you save an entry after adding two custom fields with the same label (like "URL") only the last one will be saved. No warning is displayed.

Now:
Warning is now displayed before you save entry.


