### PR TITLE
Password clipboard behavior changes

### DIFF
--- a/src/renderer/components/archive/copyable.js
+++ b/src/renderer/components/archive/copyable.js
@@ -14,6 +14,7 @@ const Password = styled(ColoredDigits)`
   font-family: Anonymous;
   font-size: 14px;
   font-weight: bold;
+  user-select: all !important;
 
   .num {
     color: var(--brand-primary-darker);
@@ -106,6 +107,10 @@ class Copyable extends PureComponent {
         role="content"
         value={content}
         concealed={this.state.concealed}
+        onCopy={e => {
+          e.preventDefault();
+          this.handleCopy(true);
+        }}
       />
     );
   }

--- a/src/renderer/system/shortcuts.js
+++ b/src/renderer/system/shortcuts.js
@@ -1,22 +1,14 @@
 import Mousetrap from 'mousetrap';
-import ms from 'ms';
 import { lockArchive } from '../../shared/actions/archives';
 import { getCurrentArchiveId, getCurrentEntry } from '../../shared/selectors';
-import { copyToClipboard, readClipboard } from './utils';
+import { copyToClipboard } from './utils';
 import { getFacadeFieldValue } from '../../shared/buttercup/entries';
-const __cache = {
-  timer: null
-};
 
 export const setupShortcuts = store => {
   /**
    * Copy password to clipboard
    */
   Mousetrap.bind('mod+c', () => {
-    if (__cache.timer) {
-      clearTimeout(__cache.timer);
-    }
-
     const selection = window.getSelection().toString();
     const currentEntry = getCurrentEntry(store.getState());
 
@@ -27,15 +19,7 @@ export const setupShortcuts = store => {
         return;
       }
 
-      copyToClipboard(password);
-
-      // Clean the clipboard after 15s
-      // @TODO: Make a UI for this.
-      __cache.timer = setTimeout(function clipboardPurgerClosure() {
-        if (readClipboard() === password) {
-          copyToClipboard('');
-        }
-      }, ms('15s'));
+      copyToClipboard(password, true);
     }
   });
 

--- a/src/renderer/system/utils.js
+++ b/src/renderer/system/utils.js
@@ -17,9 +17,12 @@ export function copyToClipboard(text, isPassword) {
       clearTimeout(__cache.timer);
     }
 
-    // Clean the clipboard after 15s if selection is blank
+    // Clean the clipboard after 15s if clipboard unchanged
+    // @TODO: Make a UI for this.
     __cache.timer = setTimeout(function clipboardPurgerClosure() {
-      clipboard.writeText('');
+      if (readClipboard() === text) {
+        clipboard.clear();
+      }
     }, ms('15s'));
   }
 }


### PR DESCRIPTION
Two small changes around the clipboard behavior for passwords.

- 15s password clearing only applied if clipboard has not changed
- Concealed password can be copied directly

I think these changes should satisfy #774. The use of `clear` might even resolve #626 (though I don't have a windows machine to test this with)

Not sure about the use of `!important` on the style...
Let me know what you guys think!

Fixes #774
Fixes #626