### PR TITLE
fix: display an error when an entry has duplicate custom fields

### DIFF
--- a/locales/en/base.json
+++ b/locales/en/base.json
@@ -151,6 +151,7 @@
     "delete": "Delete",
     "entry-inputs-empty-info": "Please enter at least a title.",
     "entry-title-empty-info": "Please enter a title.",
+    "custom-fields-label-duplicate": "you cannot have custom fields with the same label",
     "custom-fields-label-empty-info": "You've forgotten to set a label for one or more custom fields.",
     "are-you-sure-question": "Are you sure?",
     "displaying-entries": "Displaying {{count}} entries",

--- a/locales/fr/base.json
+++ b/locales/fr/base.json
@@ -151,6 +151,7 @@
     "delete": "Supprimer",
     "entry-inputs-empty-info": "Veuillez saisir au moins un titre.",
     "entry-title-empty-info": "Veuillez saisir un titre.",
+    "custom-fields-label-duplicate": "Vous ne pouvez pas avoir plusieurs champs personnalisés avec le même nom",
     "custom-fields-label-empty-info": "Vous avez oublié de définir un label pour un ou plusieurs champs personnalisés.",
     "are-you-sure-question": "Confirmez-vous ?",
     "displaying-entries": "{{count}} entrées affichées",

--- a/src/shared/buttercup/entries.js
+++ b/src/shared/buttercup/entries.js
@@ -57,6 +57,16 @@ export function validateEntry(entry) {
     if (fields.filter(field => !field.property).length > 0) {
       errorMessages.push(i18n.t('entry.custom-fields-label-empty-info'));
     }
+
+    if (
+      fields
+        .map(field => field.property)
+        .sort()
+        .filter((property, index, properties) => property === properties[index])
+        .length
+    ) {
+      errorMessages.push(i18n.t('entry.custom-fields-label-duplicate'));
+    }
   }
 
   if (errorMessages.length > 0) {


### PR DESCRIPTION
when a user creates custom fields with the same label, an error
message has to be throw by the form validator. if not, the custom
field is erased and only the last one is saved.

update the entry form validation function to be able to return a form
error, when we have a duplicate custom field, declared in an entry.
this action invalid the entry and prevent an eventual data loss by
canceling the update action.

Fixes: https://github.com/buttercup/buttercup-desktop/issues/717