### PR TITLE
Added build.win.publisherName in package.json to (hopefully) fix…

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,8 @@
       "perMachine": true
     },
     "win": {
-      "target": "nsis"
+      "target": "nsis",
+      "publisherName": "MadDev Oy"
     },
     "linux": {
       "target": [


### PR DESCRIPTION
According to comments in a similar issue in the electron repo (https://github.com/electron-userland/electron-builder/issues/3667#issuecomment-463227859) adding the build.win.publisherName in package.json could fix issue #805. I could not verify this though, because I cannot easily test the update mechanism.