### PR TITLE
Allow import passwords from browser csv dumps

### DIFF
--- a/package.json
+++ b/package.json
@@ -163,7 +163,7 @@
     "@buttercup/google-oauth2-client": "^0.2.1",
     "@buttercup/googledrive-client": "^0.2.1",
     "@buttercup/iconographer": "^1.2.0",
-    "@buttercup/importer": "^0.15.0",
+    "@buttercup/importer": "^1.2.0",
     "@buttercup/secure-file-host": "^0.2.1",
     "@buttercup/ui": "^1.4.2",
     "@hot-loader/react-dom": "^16.8.6",

--- a/src/main/lib/buttercup.js
+++ b/src/main/lib/buttercup.js
@@ -3,7 +3,8 @@ import {
   importFrom1PIF,
   importFromLastPass,
   importFromBitwarden,
-  importFromButtercup
+  importFromButtercup,
+  importFromCSV
 } from '@buttercup/importer';
 import { ImportTypes } from '../../shared/buttercup/types';
 
@@ -33,6 +34,8 @@ export function importArchive(type, filename, password) {
       return importFromButtercup(filename).then(archive =>
         archive.getHistory()
       );
+    case ImportTypes.BROWSERS:
+      return importFromCSV(filename).then(archive => archive.getHistory());
     default:
       throw new Error('Wrong import type provided');
   }

--- a/src/main/lib/buttercup.js
+++ b/src/main/lib/buttercup.js
@@ -34,7 +34,7 @@ export function importArchive(type, filename, password) {
       return importFromButtercup(filename).then(archive =>
         archive.getHistory()
       );
-    case ImportTypes.BROWSERS:
+    case ImportTypes.CSV_GENERIC:
       return importFromCSV(filename).then(archive => archive.getHistory());
     default:
       throw new Error('Wrong import type provided');

--- a/src/main/lib/files.js
+++ b/src/main/lib/files.js
@@ -22,6 +22,11 @@ function normalizePath(filePath) {
     filePath.replace(isWindows() ? /^file:[/]{2,3}/ : 'file://', '')
   );
   filePath = path.normalize(filePath);
+
+  if (path.extname(filePath).toLowerCase() !== '.bcup') {
+    filePath += '.bcup';
+  }
+
   return filePath;
 }
 
@@ -72,14 +77,13 @@ function showSaveDialog(focusedWindow) {
  * @param {BrowserWindow} win
  */
 export function loadFile(filePath, win, isNew = false) {
+  filePath = normalizePath(filePath);
   const payload = {
     type: ArchiveTypes.FILE,
-    path: normalizePath(filePath),
+    path: filePath,
     isNew
   };
-  if (path.extname(filePath).toLowerCase() !== '.bcup') {
-    return;
-  }
+
   if (!win) {
     win = getMainWindow();
   }

--- a/src/shared/buttercup/types.js
+++ b/src/shared/buttercup/types.js
@@ -12,6 +12,7 @@ export const ImportTypes = {
   KEEPASS: 'keepass',
   LASTPASS: 'lastpass',
   ONE_PASSWORD: '1password',
+  BROWSERS: 'browsers',
   BITWARDEN: 'bitwarden'
 };
 
@@ -40,6 +41,12 @@ export const ImportTypeInfo = {
     password: false,
     name: 'Buttercup (CSV)',
     extension: 'csv'
+  },
+  [ImportTypes.BROWSERS]: {
+    password: false,
+    name: 'Browsers (CSV)',
+    extension: 'csv',
+    hidden: true
   }
 };
 

--- a/src/shared/buttercup/types.js
+++ b/src/shared/buttercup/types.js
@@ -12,7 +12,7 @@ export const ImportTypes = {
   KEEPASS: 'keepass',
   LASTPASS: 'lastpass',
   ONE_PASSWORD: '1password',
-  BROWSERS: 'browsers',
+  CSV_GENERIC: 'csv_generic',
   BITWARDEN: 'bitwarden'
 };
 
@@ -42,9 +42,9 @@ export const ImportTypeInfo = {
     name: 'Buttercup (CSV)',
     extension: 'csv'
   },
-  [ImportTypes.BROWSERS]: {
+  [ImportTypes.CSV_GENERIC]: {
     password: false,
-    name: 'Browsers (CSV)',
+    name: 'Generic (CSV)',
     extension: 'csv',
     hidden: true
   }


### PR DESCRIPTION
Fixed closing the window during the creation of a new archive when file extension is not specified.
Also added password import from CSV browser dump.

Checked on Ubuntu 19.10