### PR TITLE
Fixing Issue #919: WebDav Returns 404 While Endpoint Tailed With Slashes

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -13,7 +13,7 @@
     "@buttercup/importer": "^0.15.0",
     "buttercup": "^2.16.1",
     "conf": "^1.0.0",
-    "webdav": "^2.9.1",
+    "webdav": "^2.10.1",
     "zxcvbn": "^4.4.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -279,7 +279,7 @@
     "tmp": "0.0.33",
     "url-loader": "^1.1.2",
     "uuid": "^2.0.3",
-    "webdav": "^2.9.1",
+    "webdav": "^2.10.1",
     "webpack": "^4.35.3",
     "webpack-cli": "^3.3.5",
     "webpack-dev-server": "^3.7.2",


### PR DESCRIPTION
Fixing Issue #919: WebDav Returns 404 While Endpoint Tailed With Slashes

Update the v2.10.1 of webdav package which has fixed the relevant issue. 