### PR TITLE
Add select text for incorrect password input

### DIFF
--- a/src/renderer/components/password-modal.js
+++ b/src/renderer/components/password-modal.js
@@ -156,6 +156,7 @@ class PasswordModal extends PureComponent {
             });
             if (this._currentInputRef) {
               this._currentInputRef.focus();
+              this._currentInputRef.select();
             }
           });
       }


### PR DESCRIPTION
Fixes: #874  
When opening a Buttercup archive with an incorrect password, the entered password is selected for easier re-entry.