### PR TITLE
feat: force .bcup extension for new vault

### DIFF
--- a/src/main/lib/files.js
+++ b/src/main/lib/files.js
@@ -78,7 +78,12 @@ export function loadFile(filePath, win, isNew = false) {
     isNew
   };
   if (path.extname(filePath).toLowerCase() !== '.bcup') {
-    return;
+    if (!isNew) {
+      return;
+    }
+
+    // automatically add the .bcup extension to new archive.
+    payload.path = normalizePath(filePath + '.bcup');
   }
   if (!win) {
     win = getMainWindow();


### PR DESCRIPTION
when creating a new vault the user enter a name. Be sure to force the
new vault name with .bcup extension to be able to finalize the
archive creation (open the archive and create a password).

Fixes: https://github.com/buttercup/buttercup-desktop/issues/860