### PR TITLE
show vault's title on password modal

### DIFF
--- a/src/renderer/components/password-modal.js
+++ b/src/renderer/components/password-modal.js
@@ -33,6 +33,7 @@ const ArchiveName = styled.div`
   text-transform: lowercase;
   font-weight: 400;
   color: var(--gray-darker);
+  margin-top: -10px;
 `;
 
 const ErrorContainer = styled.div`

--- a/src/renderer/components/password-modal.js
+++ b/src/renderer/components/password-modal.js
@@ -26,6 +26,15 @@ const Title = styled.h2`
   color: var(--gray-darker);
 `;
 
+const ArchiveName = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  font-size: 10px;
+  text-transform: lowercase;
+  font-weight: 400;
+  color: var(--gray-darker);
+`;
+
 const ErrorContainer = styled.div`
   background-color: var(--gray-light);
   border-radius: 3px;
@@ -70,7 +79,8 @@ class PasswordModal extends PureComponent {
     onCancel: PropTypes.func,
     t: PropTypes.func,
     confirmPassword: PropTypes.bool,
-    askForOldPassword: PropTypes.bool
+    askForOldPassword: PropTypes.bool,
+    selectedArchiveName: PropTypes.string
   };
 
   state = {
@@ -179,7 +189,12 @@ class PasswordModal extends PureComponent {
       oldPassword,
       oldPasswordSubmitted
     } = this.state;
-    const { t, confirmPassword, askForOldPassword } = this.props;
+    const {
+      t,
+      confirmPassword,
+      askForOldPassword,
+      selectedArchiveName
+    } = this.props;
     const mainTitleKey = confirmPassword
       ? 'password-dialog.new-password'
       : 'password-dialog.master-password';
@@ -205,6 +220,9 @@ class PasswordModal extends PureComponent {
         isOpen
         onRequestClose={loading ? () => {} : this.props.onCancel}
       >
+        <If condition={selectedArchiveName}>
+          <ArchiveName>{selectedArchiveName}</ArchiveName>
+        </If>
         <Translate
           i18nKey={
             askForOldPassword && !oldPasswordSubmitted

--- a/src/renderer/components/sidebar.js
+++ b/src/renderer/components/sidebar.js
@@ -35,7 +35,8 @@ class RecentFiles extends PureComponent {
     onChangeColour: PropTypes.func.isRequired,
     onChangeOrder: PropTypes.func.isRequired,
     showImportDialog: PropTypes.func.isRequired,
-    onExportArchive: PropTypes.func.isRequired
+    onExportArchive: PropTypes.func.isRequired,
+    selectedArchive: PropTypes.string
   };
 
   onSortEnd = ({ oldIndex, newIndex }) => {
@@ -47,7 +48,12 @@ class RecentFiles extends PureComponent {
   };
 
   render() {
-    const { archives, currentArchiveId, condenced } = this.props;
+    const {
+      archives,
+      currentArchiveId,
+      condenced,
+      selectedArchive
+    } = this.props;
 
     const footer = <AddArchiveButton dark full condenced={condenced} />;
 
@@ -61,7 +67,10 @@ class RecentFiles extends PureComponent {
         >
           {archives.map((archive, i) => (
             <SidebarItem
-              active={archive.id === currentArchiveId}
+              active={
+                archive.id === currentArchiveId ||
+                selectedArchive === archive.id
+              }
               archive={archive}
               key={archive.id}
               index={i}

--- a/src/renderer/components/workspace.js
+++ b/src/renderer/components/workspace.js
@@ -28,7 +28,8 @@ class Workspace extends PureComponent {
     isArchiveSearchVisible: PropTypes.bool,
     setColumnSize: PropTypes.func,
     isVaultUnlocked: PropTypes.func,
-    onValidate: PropTypes.func
+    onValidate: PropTypes.func,
+    getSelectedArchiveName: PropTypes.func
   };
 
   state = {
@@ -100,16 +101,23 @@ class Workspace extends PureComponent {
       archivesLoading,
       savingArchive,
       isArchiveSearchVisible,
-      onValidate
+      onValidate,
+      getSelectedArchiveName
     } = this.props;
     const { modalRequest } = this.state;
+
+    // the modal object have the selected archive id as payload.
+    const selectedArchive = modalRequest && modalRequest.payload;
 
     return (
       <>
         <GlobalStyles />
         <Flex flexAuto>
           <If condition={archivesCount > 0}>
-            <Sidebar condenced={condencedSidebar} />
+            <Sidebar
+              condenced={condencedSidebar}
+              selectedArchive={selectedArchive}
+            />
           </If>
           <Primary flexAuto>
             <Choose>
@@ -154,6 +162,7 @@ class Workspace extends PureComponent {
             onSuccess={this.handlePasswordModalClose}
             confirmPassword={modalRequest.confirm}
             askForOldPassword={!!modalRequest.askForOldPassword}
+            selectedArchiveName={getSelectedArchiveName(modalRequest.payload)}
           />
         </If>
       </>

--- a/src/renderer/containers/workspace.js
+++ b/src/renderer/containers/workspace.js
@@ -48,7 +48,12 @@ export default connect(
     },
     isVaultUnlocked: vaultId => (_, getState) =>
       getArchive(getState(), vaultId).status === 'unlocked',
-    getSelectedArchiveName: vaultId => (_, getState) =>
-      getArchive(getState(), vaultId).name
+    getSelectedArchiveName: vaultId => (_, getState) => {
+      const archive = getArchive(getState(), vaultId);
+
+      if (archive) return archive.name;
+
+      return null;
+    }
   }
 )(Workspace, 'Workspace');

--- a/src/renderer/containers/workspace.js
+++ b/src/renderer/containers/workspace.js
@@ -47,6 +47,8 @@ export default connect(
       }
     },
     isVaultUnlocked: vaultId => (_, getState) =>
-      getArchive(getState(), vaultId).status === 'unlocked'
+      getArchive(getState(), vaultId).status === 'unlocked',
+    getSelectedArchiveName: vaultId => (_, getState) =>
+      getArchive(getState(), vaultId).name
   }
 )(Workspace, 'Workspace');


### PR DESCRIPTION
## Description

when opening an archive (on the sidebar), pass the item to active to
show to the user the selected item. Pass the archive name to the
password modal to display the archive name.
manage the selected archive from modalRequest state from the workspace and
pass the info to the sidebar to make it active. retrieve and pass the
name to the password modal to be able to display the archive name.

Fixes: #812

## Screenshot

![password-name](https://user-images.githubusercontent.com/10661789/97115726-93110a00-16f8-11eb-8a5a-78ebe4875836.png)
