### PR TITLE
Remove node.js version in TravisCI $NAME variable, cc #799

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 env: 
-  - NAME="Node 10"
+  - NAME="Node"
 install:
   - npm ci
 services:


### PR DESCRIPTION
As the node version is not defined in `.travis.yml` anymore, should also remove it in the `$NAME` variable, in case the version was updated in the future but the name wasn't, which will be confusing.

