### PR TITLE
Fix installation instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Ensure that you never share your master password or use it anywhere other than w
 If you're using macOS, you can also use **Homebrew Cask** to download and install Buttercup:
 
 ```shell
-$ brew cask install buttercup
+$ brew install --cask buttercup
 ```
 
 If you're using Windows, you can use [**Chocolatey**](https://chocolatey.org/) to download and install [Buttercup](https://chocolatey.org/packages/buttercup):


### PR DESCRIPTION
Fix error when installing using latest Homebrew. This is not a bug of this app, but README.md needs to be fixed.

Close #966 