### PR TITLE
Fix bug when creating a new vault in Linux without '.bcup' extension

### DIFF
--- a/src/main/lib/files.js
+++ b/src/main/lib/files.js
@@ -60,7 +60,7 @@ function showSaveDialog(focusedWindow) {
     })
     .then(({ filePath }) => {
       if (typeof filePath === 'string' && filePath.length > 0) {
-        if (path.extname(filePath).toLowerCase() != '.bcup') {
+        if (path.extname(filePath).toLowerCase() !== '.bcup') {
           filePath += '.bcup';
         }
         loadFile(filePath, focusedWindow, true);

--- a/src/main/lib/files.js
+++ b/src/main/lib/files.js
@@ -60,6 +60,9 @@ function showSaveDialog(focusedWindow) {
     })
     .then(({ filePath }) => {
       if (typeof filePath === 'string' && filePath.length > 0) {
+        if (path.extname(filePath).toLowerCase() != '.bcup') {
+          filePath += '.bcup';
+        }
         loadFile(filePath, focusedWindow, true);
       }
     });


### PR DESCRIPTION
## Issue
Nothing happens when Linux users are prompted to set a file name for a new vault if 
they enter a filename without the '.bcup' file extension.  No file is created and no notification is displayed, the file dialog box just closes with no indication that it failed to create the vault other than the fact there is no new vault.  

## Expected 
Either add the extension automatically or notify user that the file name must contain a '.bcup' extension.

### Steps to Reproduce
Attempt to create a new vault without specifying the '.bcup' extension in the filename on Linux.

### Notes
It looks like code from a previous fix in the loadFile function returns empty if the filePath does not have the '.bcup' extension causing this to occur.

## Changes Made
I added code in the showSaveDialog function to check if the filePath ends with '.bcup' and if not then append it the string. 

Fixes: #955