### PR TITLE
Fixed Biometrics Crash

### DIFF
--- a/source/main/services/biometrics.ts
+++ b/source/main/services/biometrics.ts
@@ -67,7 +67,11 @@ export async function sourceEnabledForBiometricUnlock(sourceID: VaultSourceID): 
 }
 
 export async function supportsBiometricUnlock(): Promise<boolean> {
-    return systemPreferences.canPromptTouchID();
+    try {
+        return systemPreferences.canPromptTouchID();
+    } catch (err) {
+        return false;
+    }
 }
 
 async function storePassword(sourceID: VaultSourceID, password: string): Promise<void> {


### PR DESCRIPTION
Fixed the crash due to `TypeError: electron_1.systemPreferences.canPromptTouchID is not a function` mentioned in #990 and likely also the cause of #993. 
Currently tested this on Manjaro Linux.

EDIT: Fixes #993