### PR TITLE
Remove appimage version

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,36 @@
     "asar": true,
     "productName": "Buttercup",
     "copyright": "Copyright © MadDev Oy",
+    "files": [
+      "build/**/*",
+      "resources/**/*",
+      "package.json"
+    ],
+    "fileAssociations": {
+      "ext": "bcup",
+      "name": "Buttercup Vault",
+      "icon": "./resources/build/icon.icns"
+    },
+    "linux": {
+      "icon": "./resources/build/icons",
+      "target": [
+        "AppImage"
+      ],
+      "category": "Utility",
+      "synopsis": "Free and Open Source Password Vault"
+    },
+    "appImage": {
+      "artifactName": "${productName}-${os}-x64.${ext}"
+    },
+    "mac": {
+      "category": "public.app-category.productivity",
+      "darkModeSupport": true,
+      "entitlements": "./resources/build/entitlements.plist",
+      "entitlementsInherit": "./resources/build/entitlements.plist",
+      "gatekeeperAssess": false,
+      "hardenedRuntime": true,
+      "icon": "./resources/build/icon.icns"
+    },
     "dmg": {
       "artifactName": "${productName}-${os}-x64-${version}.${ext}",
       "background": "./resources/build/background@2x.png",
@@ -79,42 +109,6 @@
         "width": 660,
         "height": 480
       }
-    },
-    "files": [
-      "build/**/*",
-      "resources/**/*",
-      "package.json"
-    ],
-    "fileAssociations": {
-      "ext": "bcup",
-      "name": "Buttercup Vault",
-      "icon": "./resources/build/icon.icns"
-    },
-    "linux": {
-      "artifactName": "${productName}-${os}-x64-${version}.${ext}",
-      "icon": "./resources/build/icons",
-      "target": [
-        "AppImage"
-      ],
-      "category": "Utility",
-      "synopsis": "Free and Open Source Password Vault"
-    },
-    "mac": {
-      "category": "public.app-category.productivity",
-      "darkModeSupport": true,
-      "entitlements": "./resources/build/entitlements.plist",
-      "entitlementsInherit": "./resources/build/entitlements.plist",
-      "gatekeeperAssess": false,
-      "hardenedRuntime": true,
-      "icon": "./resources/build/icon.icns"
-    },
-    "nsis": {
-      "artifactName": "${productName}-${os}-x64-${version}-installer.${ext}",
-      "perMachine": true,
-      "include": "./resources/build/installer.nsh"
-    },
-    "portable": {
-      "artifactName": "${productName}-${os}-x64-${version}-portable.${ext}"
     },
     "protocols": {
       "name": "Buttercup",
@@ -139,6 +133,14 @@
         "portable"
       ],
       "publisherName": "MadDev Oy"
+    },
+    "nsis": {
+      "artifactName": "${productName}-${os}-x64-${version}-installer.${ext}",
+      "perMachine": true,
+      "include": "./resources/build/installer.nsh"
+    },
+    "portable": {
+      "artifactName": "${productName}-${os}-x64-${version}-portable.${ext}"
     }
   },
   "dependencies": {


### PR DESCRIPTION
Removes the AppImage artifact version from its filename, preventing the renaming of the AppImage after auto updating.

Fixes #1004