### PR TITLE
--no-window CL argument

### DIFF
--- a/source/main/index.ts
+++ b/source/main/index.ts
@@ -3,6 +3,7 @@ import "./ipc";
 import { initialise } from "./services/init";
 import { openMainWindow } from "./services/windows";
 import { handleProtocolCall } from "./services/protocol";
+import { shouldShowMainWindow } from "./services/arguments";
 import { logErr, logInfo } from "./library/log";
 import { BUTTERCUP_PROTOCOL, PLATFORM_MACOS } from "./symbols";
 
@@ -52,7 +53,13 @@ app.whenReady()
         logInfo("Application ready");
     })
     .then(() => initialise())
-    .then(() => openMainWindow())
+    .then(() => {
+        if (!shouldShowMainWindow()) {
+            logInfo("Opening initial window disabled");
+            return;
+        }
+        openMainWindow();
+    })
     .catch((err) => {
         logErr(err);
         app.quit();

--- a/source/main/services/arguments.ts
+++ b/source/main/services/arguments.ts
@@ -1,0 +1,14 @@
+import { app } from "electron";
+
+let __showMainWindow = true;
+
+export function processCLFlags() {
+    const cl = app.commandLine;
+    if (cl.hasSwitch("no-window")) {
+        __showMainWindow = false;
+    }
+}
+
+export function shouldShowMainWindow(): boolean {
+    return __showMainWindow;
+}

--- a/source/main/services/init.ts
+++ b/source/main/services/init.ts
@@ -12,11 +12,13 @@ import { isPortable } from "../library/portability";
 import { getLogPath } from "./log";
 import { startUpdateWatcher } from "./update";
 import { registerGoogleDriveAuthHandlers } from "./googleDrive";
+import { processCLFlags } from "./arguments";
 import { initialise as initialiseI18n, onLanguageChanged } from "../../shared/i18n/trans";
 import { getLanguage } from "../../shared/library/i18n";
 import { Preferences } from "../types";
 
 export async function initialise() {
+    processCLFlags();
     await initialiseLogging();
     logInfo("Application session started:", new Date());
     logInfo(`Logs location: ${getLogPath()}`);


### PR DESCRIPTION
This PR adds support for a new command line argument do prevent opening the window initially. This is especially useful for auto-starting the app daemon when the OS boots.

Specifying `--no-window` against the Buttercup executable will start the tray daemon but not open any main window.

Fixes #951