### PR TITLE
Linux protocol bugfix

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ _Note that at this time, Buttercup only supports x64 (64 bit) machines._
 
 We provide an **AppImage** build for Linux, because it is the most desirable format for us to release. AppImages support auto-updating, a crucial feature (we feel) for a security application. The other build types do not.
 
+**Important:** Buttercup uses Electron to build its desktop application, which relies on [**AppImageLauncher**](https://github.com/TheAssassin/AppImageLauncher#readme) for correct integration of AppImages into the host OS. Features like **Google Drive** authentication and correct `.desktop` icon use is only performed when integrating via AppImageLauncher. We highly recommend that you install it.
+
 We won't be supporting formats like Snapcraft, deb or rpm images as they do not align with our requirements. Issues requesting these formats will be closed immediately. Discussion on topics like this should be started on other social channels.
 
 ## Development

--- a/package.json
+++ b/package.json
@@ -74,10 +74,14 @@
         "AppImage"
       ],
       "category": "Utility",
-      "synopsis": "Free and Open Source Password Vault"
-    },
-    "appImage": {
-      "artifactName": "${productName}-${os}-x64.${ext}"
+      "synopsis": "Free and Open Source Password Vault",
+      "artifactName": "${productName}-${os}-x64.${ext}",
+      "desktop": {
+        "Name": "Buttercup Password Manager",
+        "Type": "Application",
+        "Comment": "A free and open-source password management application",
+        "Terminal": "false"
+      }
     },
     "mac": {
       "category": "public.app-category.productivity",
@@ -110,12 +114,10 @@
         "height": 480
       }
     },
-    "protocols": {
-      "name": "Buttercup",
-      "schemes": [
-        "buttercup"
-      ]
-    },
+    "protocols": [{
+      "name": "buttercup",
+      "schemes": ["buttercup"]
+    }],
     "publish": [
       {
         "provider": "github",

--- a/source/main/index.ts
+++ b/source/main/index.ts
@@ -7,6 +7,8 @@ import { shouldShowMainWindow } from "./services/arguments";
 import { logErr, logInfo } from "./library/log";
 import { BUTTERCUP_PROTOCOL, PLATFORM_MACOS } from "./symbols";
 
+logInfo("Application starting");
+
 const lock = app.requestSingleInstanceLock();
 if (!lock) {
     app.quit();
@@ -27,6 +29,7 @@ app.on("activate", () => {
 // **
 // ** App protocol handling
 // **
+
 app.on("second-instance", async (event, args) => {
     await openMainWindow();
     // Protocol URL for Linux/Windows
@@ -42,7 +45,18 @@ app.on("open-url", (e, url) => {
     }
 });
 
-app.setAsDefaultProtocolClient(BUTTERCUP_PROTOCOL.replace("://", ""));
+{
+    const protocol = BUTTERCUP_PROTOCOL.replace("://", "");
+    if (!app.isDefaultProtocolClient(protocol)) {
+        logInfo(`Registering protocol: ${protocol}`);
+        const protoReg = app.setAsDefaultProtocolClient(protocol);
+        if (!protoReg) {
+            logErr(`Failed registering protocol: ${protocol}`);
+        }
+    } else {
+        logInfo(`Protocol already registered: ${protocol}`);
+    }
+}
 
 // **
 // ** Boot


### PR DESCRIPTION
This MR adds some build config improvements around `AppImage` and protocol support. Protocol support is required for features like **Google Drive** to work.

Closes #1040
Closes #1037