### PR TITLE
fix(1011): search not working due to org.freedesktop.secrets missing

### DIFF
--- a/source/main/services/biometrics.ts
+++ b/source/main/services/biometrics.ts
@@ -63,8 +63,14 @@ export async function getSourcePasswordViaBiometrics(sourceID: VaultSourceID): P
 }
 
 export async function sourceEnabledForBiometricUnlock(sourceID: VaultSourceID): Promise<boolean> {
-    const password = await keytar.getPassword(APP_ID, sourceID);
-    return !!password;
+    try {
+        const password = await keytar.getPassword(APP_ID, sourceID);
+        return !!password;
+    } catch (e) {
+        logWarn("keytar.getPassword failed", e);
+    }
+
+    return false;
 }
 
 export async function supportsBiometricUnlock(): Promise<boolean> {


### PR DESCRIPTION
Fixes #1011.

Not sure if the error handling is correct, let me know if I should handle it differently (I figured a warning is enough).