### PR TITLE
Ask for password again when mistyped

### DIFF
--- a/source/renderer/actions/unlockVault.ts
+++ b/source/renderer/actions/unlockVault.ts
@@ -20,7 +20,7 @@ export async function unlockVaultSource(sourceID: VaultSourceID): Promise<boolea
             }`
         );
         setBusy(false);
-        return false;
+        unlockVaultSource(sourceID);
     }
     setBusy(false);
     logInfo(`Unlocked source: ${sourceID}`);

--- a/source/renderer/actions/unlockVault.ts
+++ b/source/renderer/actions/unlockVault.ts
@@ -20,7 +20,7 @@ export async function unlockVaultSource(sourceID: VaultSourceID): Promise<boolea
             }`
         );
         setBusy(false);
-        unlockVaultSource(sourceID);
+        return await unlockVaultSource(sourceID);
     }
     setBusy(false);
     logInfo(`Unlocked source: ${sourceID}`);


### PR DESCRIPTION
If we cannot open the vault with the password provided by the user, we now ask again for his vault password.

This aims at solving the issue #1065 

The new behavior for a wrong password is:
1. The user click on open a vault
2. He is asked for the vault password
3. He types the wrong password
4. The password prompt dialog closes, the processing gif is displayed, busy state, we attempt to unlock the vault
5. The vault unlock attempt finishes and results in a rejected promise
5. The busy state is set to false, the processing gif disappear and an error message is displayed
6. We ask again for the user vault password: the password prompt is opened again

Note that we will ask for the password again without knowing if it was a wrong password that caused the method `ipcRenderer.invoke("unlock-source", sourceID, password);` to fail.
