### PR TITLE
Added extra build targets for AppImage Distribution

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,8 +70,16 @@
     },
     "linux": {
       "icon": "./resources/build/icons",
-      "target": [
-        "AppImage"
+      "target":
+        [
+          {
+            "target": "appImage",
+            "arch": [
+              "x64",
+              "armv7l",
+              "arm64"
+            ]
+          }
       ],
       "category": "Utility",
       "synopsis": "Free and Open Source Password Vault",


### PR DESCRIPTION
I've tested the arm64 distribution and its working flawlessly. You can check out the binary at my fork. Resolves #1088 