### PR TITLE
add lock vault in global menu

### DIFF
--- a/source/main/actions/appMenu.ts
+++ b/source/main/actions/appMenu.ts
@@ -146,14 +146,13 @@ async function getContextMenu(): Promise<Menu> {
                 },
                 { type: "separator" },
                 {
-                    label: t("app-menu.lock-vault"),
+                    label: t("app-menu.lock-current-vault"),
                     enabled: !!lastSource,
                     accelerator: isOSX() ? "Cmd+L" : "Ctrl+L",
                     click: async () => {
                         if (lastSource.state !== VaultSourceStatus.Unlocked) {
                             return;
                         }
-
                         return lockSource(lastSource.id);
                     }
                 },

--- a/source/shared/i18n/translations/ca_es.json
+++ b/source/shared/i18n/translations/ca_es.json
@@ -70,6 +70,7 @@
         "export": "Exportar",
         "import": "Importar",
         "lock-all": "Bloquejar tots",
+        "lock-current-vault": "Bloquejar cofre actual",
         "open": "Obrir",
         "open-vault": "Obrir cofre",
         "preferences": "Preferències",

--- a/source/shared/i18n/translations/de.json
+++ b/source/shared/i18n/translations/de.json
@@ -70,6 +70,7 @@
         "export": "Exportieren",
         "import": "Importieren",
         "lock-all": "Sperre Alles",
+        "lock-current-vault": "Sperre aktuellen Tresor",
         "open": "Öffnen",
         "open-vault": "Öffne Tresor",
         "preferences": "Einstellungen",

--- a/source/shared/i18n/translations/en.json
+++ b/source/shared/i18n/translations/en.json
@@ -70,7 +70,7 @@
         "export": "Export",
         "import": "Import",
         "lock-all": "Lock All",
-        "lock-vault": "Lock current vault",
+        "lock-current-vault": "Lock current vault",
         "open": "Open",
         "open-vault": "Open Vault",
         "preferences": "Preferences",

--- a/source/shared/i18n/translations/es.json
+++ b/source/shared/i18n/translations/es.json
@@ -70,6 +70,7 @@
         "export": "Exportar",
         "import": "Importar",
         "lock-all": "Bloquear todos",
+        "lock-current-vault": "Bloquear cofre actual",
         "open": "Abrir",
         "open-vault": "Abrir cofre",
         "preferences": "Preferencias",

--- a/source/shared/i18n/translations/fr.json
+++ b/source/shared/i18n/translations/fr.json
@@ -68,7 +68,7 @@
         "edit": "Modifier",
         "enable-secure-file-host": "Activer l’accès par navigateur",
         "lock-all": "Tout verrouiller",
-        "lock-vault": "Verouiller le coffre-fort courant",
+        "lock-current-vault": "Verrouiller le coffre-fort actuel",
         "open": "Ouvrir",
         "open-vault": "Ouvrir le coffre-fort",
         "preferences": "Préférences",

--- a/source/shared/i18n/translations/it.json
+++ b/source/shared/i18n/translations/it.json
@@ -70,6 +70,7 @@
         "export": "Esporta",
         "import": "Importa",
         "lock-all": "Blocca tutti",
+        "lock-current-vault": "Blocca l'archivio corrente",
         "open": "Apri",
         "open-vault": "Apri archivio",
         "preferences": "Preferenze",

--- a/source/shared/i18n/translations/pl.json
+++ b/source/shared/i18n/translations/pl.json
@@ -66,6 +66,7 @@
         "edit": "Edytuj",
         "enable-secure-file-host": "Włącz dostęp przeglądarki",
         "lock-all": "Zablokuj",
+        "lock-current-vault": "Zablokuj aktualne archiwum",
         "open": "Otwórz",
         "open-vault": "Otwórz archiwum",
         "preferences": "Ustawienia",

--- a/source/shared/i18n/translations/ro.json
+++ b/source/shared/i18n/translations/ro.json
@@ -70,6 +70,7 @@
         "export": "Exportă",
         "import": "Importă",
         "lock-all": "Blochează-le pe Toate",
+        "lock-current-vault": "Blochează Seiful Curent",
         "open": "Deschide",
         "open-vault": "Deschide Seiful",
         "preferences": "Preferințe",


### PR DESCRIPTION
## DESCRIPTION

Add an entry to the global menu to lock the current vault, This PR have 2 commits:

* add the entry to the menu and add an associated `Ctrl-L` keyboard shortcut.
* add a similar shortcut to the lock all vaults menu entry `Ctrl-Alt-L`

## ATTACHED ISSUE

#1096 : add lock current vault to the menu