### PR TITLE
Modify NSIS options to allow installing Buttercup per-user

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ We won't be supporting formats like Snapcraft, deb or rpm images as they do not 
 
 ## Development
 
-To begin developing features or bug-fixes for Buttercup Desktop, make sure that you first have Node v14 installed with a current version of NPM.
+To begin developing features or bug-fixes for Buttercup Desktop, make sure that you first have Node v16 or greater installed with NPM v7 or greater.
 
 Once cloned, make sure to install all dependencies: `npm install`. After that, open 2 terminals and run `npm run start:build` on one, and then `npm run start:main` in the other.
 

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ We won't be supporting formats like Snapcraft, deb or rpm images as they do not 
 
 To begin developing features or bug-fixes for Buttercup Desktop, make sure that you first have Node v14 installed with a current version of NPM.
 
-Once cloned, make sure to install all dependencies: `npm install`. After that, open 2 terminals and run `npm run start:renderer` in one and `npm run start:main` in the other.
+Once cloned, make sure to install all dependencies: `npm install`. After that, open 2 terminals and run `npm run start:build` on one, and then `npm run start:main` in the other.
 
 ### Contributing
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@buttercup/importer": "^3.1.0",
         "@buttercup/secure-file-host": "^0.3.0",
         "@electron/remote": "^2.0.8",
+        "auto-launch": "^5.0.6",
         "buttercup": "^7.3.0",
         "debounce": "^1.2.1",
         "debounce-promise": "^3.1.2",
@@ -4827,6 +4828,11 @@
         "node": ">= 10.0.0"
       }
     },
+    "node_modules/applescript": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/applescript/-/applescript-1.0.0.tgz",
+      "integrity": "sha512-yvtNHdWvtbYEiIazXAdp/NY+BBb65/DAseqlNiJQjOx9DynuzOYDbVLBJvuc0ve0VL9x6B3OHF6eH52y9hCBtQ=="
+    },
     "node_modules/aproba": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
@@ -5028,6 +5034,21 @@
       },
       "engines": {
         "node": ">= 4.5.0"
+      }
+    },
+    "node_modules/auto-launch": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/auto-launch/-/auto-launch-5.0.6.tgz",
+      "integrity": "sha512-OgxiAm4q9EBf9EeXdPBiVNENaWE3jUZofwrhAkWjHDYGezu1k3FRZHU8V2FBxGuSJOHzKmTJEd0G7L7/0xDGFA==",
+      "dependencies": {
+        "applescript": "^1.0.0",
+        "mkdirp": "^0.5.1",
+        "path-is-absolute": "^1.0.0",
+        "untildify": "^3.0.2",
+        "winreg": "1.2.4"
+      },
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/babel-jest": {
@@ -13884,7 +13905,6 @@
       "version": "0.5.5",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
       "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-      "dev": true,
       "dependencies": {
         "minimist": "^1.2.5"
       },
@@ -15185,7 +15205,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -18897,6 +18916,14 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/untildify": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/untildify/-/untildify-3.0.3.tgz",
+      "integrity": "sha512-iSk/J8efr8uPT/Z4eSUywnqyrQU7DSdMfdqK4iWEaUVVmcP5JcnpRqmVMwcwcnmI1ATFNgC5V90u09tBynNFKA==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/update-browserslist-db": {
       "version": "1.0.13",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz",
@@ -19734,6 +19761,11 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/winreg": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/winreg/-/winreg-1.2.4.tgz",
+      "integrity": "sha512-IHpzORub7kYlb8A43Iig3reOvlcBJGX9gZ0WycHhghHtA65X0LYnMRuJs+aH1abVnMJztQkvQNlltnbPi5aGIA=="
     },
     "node_modules/with": {
       "version": "5.1.1",
@@ -23722,6 +23754,11 @@
         }
       }
     },
+    "applescript": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/applescript/-/applescript-1.0.0.tgz",
+      "integrity": "sha512-yvtNHdWvtbYEiIazXAdp/NY+BBb65/DAseqlNiJQjOx9DynuzOYDbVLBJvuc0ve0VL9x6B3OHF6eH52y9hCBtQ=="
+    },
     "aproba": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
@@ -23881,6 +23918,18 @@
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
       "dev": true
+    },
+    "auto-launch": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/auto-launch/-/auto-launch-5.0.6.tgz",
+      "integrity": "sha512-OgxiAm4q9EBf9EeXdPBiVNENaWE3jUZofwrhAkWjHDYGezu1k3FRZHU8V2FBxGuSJOHzKmTJEd0G7L7/0xDGFA==",
+      "requires": {
+        "applescript": "^1.0.0",
+        "mkdirp": "^0.5.1",
+        "path-is-absolute": "^1.0.0",
+        "untildify": "^3.0.2",
+        "winreg": "1.2.4"
+      }
     },
     "babel-jest": {
       "version": "29.7.0",
@@ -30613,7 +30662,6 @@
       "version": "0.5.5",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
       "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-      "dev": true,
       "requires": {
         "minimist": "^1.2.5"
       }
@@ -31612,8 +31660,7 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-key": {
       "version": "3.1.1",
@@ -34449,6 +34496,11 @@
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="
     },
+    "untildify": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/untildify/-/untildify-3.0.3.tgz",
+      "integrity": "sha512-iSk/J8efr8uPT/Z4eSUywnqyrQU7DSdMfdqK4iWEaUVVmcP5JcnpRqmVMwcwcnmI1ATFNgC5V90u09tBynNFKA=="
+    },
     "update-browserslist-db": {
       "version": "1.0.13",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz",
@@ -35084,6 +35136,11 @@
       "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
       "integrity": "sha512-1pTPQDKTdd61ozlKGNCjhNRd+KPmgLSGa3mZTHoOliaGcESD8G1PXhh7c1fgiPjVbNVfgy2Faw4BI8/m0cC8Mg==",
       "dev": true
+    },
+    "winreg": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/winreg/-/winreg-1.2.4.tgz",
+      "integrity": "sha512-IHpzORub7kYlb8A43Iig3reOvlcBJGX9gZ0WycHhghHtA65X0LYnMRuJs+aH1abVnMJztQkvQNlltnbPi5aGIA=="
     },
     "with": {
       "version": "5.1.1",

--- a/package.json
+++ b/package.json
@@ -196,6 +196,7 @@
     "@buttercup/importer": "^3.1.0",
     "@buttercup/secure-file-host": "^0.3.0",
     "@electron/remote": "^2.0.8",
+    "auto-launch": "^5.0.6",
     "buttercup": "^7.3.0",
     "debounce": "^1.2.1",
     "debounce-promise": "^3.1.2",

--- a/package.json
+++ b/package.json
@@ -153,7 +153,8 @@
     },
     "nsis": {
       "artifactName": "${productName}-${os}-${env.NODE_ARCHITECTURE}-${version}-installer.${ext}",
-      "perMachine": true,
+      "oneClick" : false,
+      "perMachine": false,
       "include": "./resources/build/installer.nsh"
     },
     "portable": {

--- a/package.json
+++ b/package.json
@@ -155,7 +155,7 @@
     },
     "nsis": {
       "artifactName": "${productName}-${os}-${env.NODE_ARCHITECTURE}-${version}-installer.${ext}",
-      "oneClick" : false,
+      "oneClick": false,
       "perMachine": false,
       "include": "./resources/build/installer.nsh"
     },

--- a/package.json
+++ b/package.json
@@ -86,6 +86,8 @@
       "category": "Utility",
       "synopsis": "Free and Open Source Password Vault",
       "artifactName": "${productName}-${os}-${arch}.${ext}",
+      "mimeTypes": ["x-scheme-handler/buttercup"],
+      "executableArgs": ["%u"],
       "desktop": {
         "Name": "Buttercup Password Manager",
         "Type": "Application",

--- a/source/main/actions/config.ts
+++ b/source/main/actions/config.ts
@@ -15,9 +15,18 @@ export async function handleConfigUpdate(preferences: Preferences) {
     const language = getLanguage(preferences, locale);
     logInfo(` - Language updated: ${language}`);
     await changeLanguage(language);
+    logInfo(
+        ` - Auto clear clipboard: ${
+            preferences.autoClearClipboard ? preferences.autoClearClipboard + "s" : "Off"
+        }`
+    );
+    logInfo(
+        ` - Lock vaults after: ${
+            preferences.lockVaultsAfterTime ? preferences.lockVaultsAfterTime + "s" : "Off"
+        }`
+    );
+    logInfo(` - Start in background: ${preferences.startInBackground ? "Enabled" : "Disabled"}`);
     logInfo(` - File host: ${preferences.fileHostEnabled ? "Enabled" : "Disabled"}`);
-    logInfo(` - Auto clear clipboard: ${preferences.autoClearClipboard}s`);
-    logInfo(` - Lock vaults after: ${preferences.lockVaultsAfterTime}s`);
     if (preferences.fileHostEnabled) {
         await startBrowserAPI();
         await startFileHost();

--- a/source/main/actions/config.ts
+++ b/source/main/actions/config.ts
@@ -5,39 +5,32 @@ import { changeLanguage } from "../../shared/i18n/trans";
 import { getLanguage } from "../../shared/library/i18n";
 import { startFileHost, stopFileHost } from "../services/fileHost";
 import { start as startBrowserAPI, stop as stopBrowserAPI } from "../services/browser/index";
-import { Preferences } from "../types";
 import { setStartWithSession } from "../services/config";
+import { Preferences } from "../types";
 
 export async function handleConfigUpdate(preferences: Preferences) {
     logInfo("Config updated");
     applyCurrentTheme(preferences);
-
     const locale = await getOSLocale();
     logInfo(` - System locale detected: ${locale}`);
-
     const language = getLanguage(preferences, locale);
     logInfo(` - Language updated: ${language}`);
     await changeLanguage(language);
-
     logInfo(
         ` - Auto clear clipboard: ${
             preferences.autoClearClipboard ? preferences.autoClearClipboard + "s" : "Off"
         }`
     );
-
     logInfo(
         ` - Lock vaults after: ${
             preferences.lockVaultsAfterTime ? preferences.lockVaultsAfterTime + "s" : "Off"
         }`
     );
-
     logInfo(` - Start in background: ${preferences.startInBackground ? "Enabled" : "Disabled"}`);
-
     logInfo(
         ` - Start with session launch: ${preferences.startWithSession ? "Enabled" : "Disabled"}`
     );
     await setStartWithSession(preferences.startWithSession);
-
     logInfo(` - File host: ${preferences.fileHostEnabled ? "Enabled" : "Disabled"}`);
     if (preferences.fileHostEnabled) {
         await startBrowserAPI();

--- a/source/main/actions/config.ts
+++ b/source/main/actions/config.ts
@@ -6,6 +6,7 @@ import { getLanguage } from "../../shared/library/i18n";
 import { startFileHost, stopFileHost } from "../services/fileHost";
 import { start as startBrowserAPI, stop as stopBrowserAPI } from "../services/browser/index";
 import { Preferences } from "../types";
+import { setStartWithSession } from "../services/config";
 
 export async function handleConfigUpdate(preferences: Preferences) {
     logInfo("Config updated");
@@ -35,6 +36,8 @@ export async function handleConfigUpdate(preferences: Preferences) {
     logInfo(
         ` - Start with session launch: ${preferences.startWithSession ? "Enabled" : "Disabled"}`
     );
+    await setStartWithSession(preferences.startWithSession);
+
     logInfo(` - File host: ${preferences.fileHostEnabled ? "Enabled" : "Disabled"}`);
     if (preferences.fileHostEnabled) {
         await startBrowserAPI();

--- a/source/main/actions/config.ts
+++ b/source/main/actions/config.ts
@@ -10,22 +10,31 @@ import { Preferences } from "../types";
 export async function handleConfigUpdate(preferences: Preferences) {
     logInfo("Config updated");
     applyCurrentTheme(preferences);
+
     const locale = await getOSLocale();
     logInfo(` - System locale detected: ${locale}`);
+
     const language = getLanguage(preferences, locale);
     logInfo(` - Language updated: ${language}`);
     await changeLanguage(language);
+
     logInfo(
         ` - Auto clear clipboard: ${
             preferences.autoClearClipboard ? preferences.autoClearClipboard + "s" : "Off"
         }`
     );
+
     logInfo(
         ` - Lock vaults after: ${
             preferences.lockVaultsAfterTime ? preferences.lockVaultsAfterTime + "s" : "Off"
         }`
     );
+
     logInfo(` - Start in background: ${preferences.startInBackground ? "Enabled" : "Disabled"}`);
+
+    logInfo(
+        ` - Start with session launch: ${preferences.startWithSession ? "Enabled" : "Disabled"}`
+    );
     logInfo(` - File host: ${preferences.fileHostEnabled ? "Enabled" : "Disabled"}`);
     if (preferences.fileHostEnabled) {
         await startBrowserAPI();

--- a/source/main/index.ts
+++ b/source/main/index.ts
@@ -7,6 +7,7 @@ import { handleProtocolCall } from "./services/protocol";
 import { shouldShowMainWindow } from "./services/arguments";
 import { logErr, logInfo } from "./library/log";
 import { BUTTERCUP_PROTOCOL, PLATFORM_MACOS } from "./symbols";
+import { getStartInBackground } from "./services/config";
 
 logInfo("Application starting");
 
@@ -70,9 +71,10 @@ app.whenReady()
             logInfo(`Protocol already registered: ${protocol}`);
         }
     })
-    .then(() => {
-        if (!shouldShowMainWindow()) {
-            logInfo("Opening initial window disabled");
+    .then(async () => {
+        const hideInTray = await getStartInBackground();
+        if (!shouldShowMainWindow() || hideInTray) {
+            logInfo("Opening initial window disabled by CL or preferences");
             return;
         }
         openMainWindow();

--- a/source/main/services/config.ts
+++ b/source/main/services/config.ts
@@ -100,7 +100,7 @@ export async function getStartInBackground(): Promise<boolean> {
     return preferences.startInBackground;
 }
 
-export async function setStartWithSession(enable: boolean): Promise<boolean> {
+export async function setStartWithSession(enable: boolean): Promise<void> {
     var AutoLaunch = require("auto-launch");
 
     var autoLauncher = new AutoLaunch({
@@ -108,10 +108,16 @@ export async function setStartWithSession(enable: boolean): Promise<boolean> {
     });
 
     if (enable) {
-        autoLauncher.enable();
+        autoLauncher.isEnabled().then((enabled) => {
+            if (!enabled) {
+                autoLauncher.enable();
+            }
+        });
     } else {
-        autoLauncher.disable();
+        autoLauncher.isEnabled().then((enabled) => {
+            if (enabled) {
+                autoLauncher.disable();
+            }
+        });
     }
-
-    return autoLauncher.isEnabled();
 }

--- a/source/main/services/config.ts
+++ b/source/main/services/config.ts
@@ -1,3 +1,4 @@
+import { autoLaunch } from "auto-launch";
 import fs from "fs/promises";
 import { VaultSourceID } from "buttercup";
 import { getConfigStorage, getVaultSettingsPath, getVaultSettingsStorage } from "./storage";
@@ -97,4 +98,20 @@ export async function getStartInBackground(): Promise<boolean> {
         return false;
     }
     return preferences.startInBackground;
+}
+
+export async function setStartWithSession(enable: boolean): Promise<boolean> {
+    var AutoLaunch = require("auto-launch");
+
+    var autoLauncher = new AutoLaunch({
+        name: "Buttercup"
+    });
+
+    if (enable) {
+        autoLauncher.enable();
+    } else {
+        autoLauncher.disable();
+    }
+
+    return autoLauncher.isEnabled();
 }

--- a/source/main/services/config.ts
+++ b/source/main/services/config.ts
@@ -89,3 +89,12 @@ export async function setVaultSettings(
     const storage = getVaultSettingsStorage(sourceID);
     await storage.setValues(settings);
 }
+
+export async function getStartInBackground(): Promise<boolean> {
+    const storage = getConfigStorage();
+    const preferences = await storage.getValue("preferences");
+    if (typeof preferences === "undefined") {
+        return false;
+    }
+    return preferences.startInBackground;
+}

--- a/source/main/services/config.ts
+++ b/source/main/services/config.ts
@@ -1,4 +1,4 @@
-import { autoLaunch } from "auto-launch";
+import AutoLaunch from "auto-launch";
 import fs from "fs/promises";
 import { VaultSourceID } from "buttercup";
 import { getConfigStorage, getVaultSettingsPath, getVaultSettingsStorage } from "./storage";
@@ -101,9 +101,7 @@ export async function getStartInBackground(): Promise<boolean> {
 }
 
 export async function setStartWithSession(enable: boolean): Promise<void> {
-    var AutoLaunch = require("auto-launch");
-
-    var autoLauncher = new AutoLaunch({
+    const autoLauncher = new AutoLaunch({
         name: "Buttercup"
     });
 

--- a/source/renderer/components/PreferencesDialog.tsx
+++ b/source/renderer/components/PreferencesDialog.tsx
@@ -170,6 +170,14 @@ export function PreferencesDialog() {
             </FormGroup>
             <FormGroup label={t("preferences.item.startup-options.title")}>
                 <Switch
+                    checked={preferences.startWithSession}
+                    label={t("preferences.item.startup-options.start-with-session")}
+                    onChange={(evt: React.ChangeEvent<HTMLInputElement>) => setPreferences({
+                        ...naiveClone(preferences),
+                        startWithSession: evt.target.checked,
+                    })}
+                />
+                <Switch
                     checked={preferences.startInBackground}
                     label={t("preferences.item.startup-options.start-in-background")}
                     onChange={(evt: React.ChangeEvent<HTMLInputElement>) => setPreferences({

--- a/source/renderer/components/PreferencesDialog.tsx
+++ b/source/renderer/components/PreferencesDialog.tsx
@@ -168,6 +168,16 @@ export function PreferencesDialog() {
                     />
                 </ThemeSelect>
             </FormGroup>
+            <FormGroup label={t("preferences.item.startup-options.title")}>
+                <Switch
+                    checked={preferences.startInBackground}
+                    label={t("preferences.item.startup-options.start-in-background")}
+                    onChange={(evt: React.ChangeEvent<HTMLInputElement>) => setPreferences({
+                        ...naiveClone(preferences),
+                        startInBackground: evt.target.checked
+                    })}
+                />
+            </FormGroup>
         </>
     );
     const pageSecurity = () => (

--- a/source/shared/i18n/translations/en.json
+++ b/source/shared/i18n/translations/en.json
@@ -260,6 +260,10 @@
                 "label": "Enable secure file host",
                 "title": "Secure file host"
             },
+            "startup-options": {
+                "title": "Startup options",
+                "start-in-background": "Start application in background"
+            },
             "theme": "Theme"
         },
         "section": {

--- a/source/shared/i18n/translations/en.json
+++ b/source/shared/i18n/translations/en.json
@@ -262,6 +262,7 @@
             },
             "startup-options": {
                 "title": "Startup options",
+                "start-with-session" : "Auto-start application when my session launches",
                 "start-in-background": "Start application in background"
             },
             "theme": "Theme"

--- a/source/shared/symbols.ts
+++ b/source/shared/symbols.ts
@@ -26,6 +26,7 @@ export const PREFERENCES_DEFAULT: Preferences = {
     language: null,
     lockVaultsAfterTime: false, // seconds
     lockVaultsOnWindowClose: false,
+    startInBackground: false,
     uiTheme: ThemeSource.System
 };
 

--- a/source/shared/symbols.ts
+++ b/source/shared/symbols.ts
@@ -26,6 +26,7 @@ export const PREFERENCES_DEFAULT: Preferences = {
     language: null,
     lockVaultsAfterTime: false, // seconds
     lockVaultsOnWindowClose: false,
+    startWithSession: false,
     startInBackground: false,
     uiTheme: ThemeSource.System
 };

--- a/source/shared/types.ts
+++ b/source/shared/types.ts
@@ -35,6 +35,7 @@ export interface Preferences {
     language: null | string;
     lockVaultsAfterTime: false | number;
     lockVaultsOnWindowClose: boolean;
+    startWithSession: boolean;
     startInBackground: boolean;
     uiTheme: ThemeSource;
 }

--- a/source/shared/types.ts
+++ b/source/shared/types.ts
@@ -35,6 +35,7 @@ export interface Preferences {
     language: null | string;
     lockVaultsAfterTime: false | number;
     lockVaultsOnWindowClose: boolean;
+    startInBackground: boolean;
     uiTheme: ThemeSource;
 }
 


### PR DESCRIPTION
Since Buttercup Desktop will be needed with Chrome's extension (manifest v3), users that were able to install the extension on their local account may end up being unable to install Buttercup Desktop if they don't have administrative privileges.

Adding oneClick:false and changing perMachine:false will launch an installation prompt giving the user a choice to install Buttercup per-user or per-machine (system wide).

Fixes [issue 1247](https://github.com/buttercup/buttercup-desktop/issues/1247)

Tested locally without any visible regression.