### PR TITLE
Fix undefined config preference during migration

### DIFF
--- a/source/main/services/migration.ts
+++ b/source/main/services/migration.ts
@@ -8,7 +8,10 @@ const MIGRATIONS: Array<ConfigMigration> = [
     [
         "startInBackground",
         (config: Config) => {
-            if (typeof config.preferences["startInBackground"] === "boolean") {
+            if (
+                config.preferences &&
+                typeof config.preferences["startInBackground"] === "boolean"
+            ) {
                 const prefs = { ...config.preferences };
                 prefs.startMode = config.preferences["startInBackground"]
                     ? AppStartMode.HiddenAlways


### PR DESCRIPTION
This fixes the `Layerr: Failed executing config migration: startInBackground: Cannot read properties of undefined (reading 'startInBackground')` error at startup for v2.24.x.

New to Buttercup here. The Buttercup app closed itself immediately at start, right after a clean (first) install. The error below showed up if I opened the app in a terminal.
```
[INF] 11:30:29: Application starting
[INF] 11:30:30: Application ready
[INF] 11:30:30: Application session started: 2023-12-16T11:30:30.182Z
[INF] 11:30:30: Logs location: C:\Users\USER\AppData\Local\Buttercup-nodejs\Log\buttercup-desktop.log
[INF] 11:30:30: Config location: C:\Users\USER\AppData\Roaming\Buttercup-nodejs\Config\desktop.config.json
[INF] 11:30:30: Vault config storage location: C:\Users\USER\AppData\Local\Buttercup-nodejs\Data\vaults.json
[INF] 11:30:30: Vault-specific settings path: C:\Users\USER\AppData\Roaming\Buttercup-nodejs\Config\vault-config-<ID>.json
[ERR] 11:30:30: Layerr: Failed executing config migration: startInBackground: Cannot read properties of undefined (reading 'startInBackground')
at runConfigMigrations  build/main/index.js:49582  throw new layerr_1.Layerr(err, `Failed executing config migration: ${name}`);
at                      build/main/index.js:48756  const [updatedConfig, didMigrate] = (0, migration_1.runConfigMigrations)(config??at next

at fulfilled            build/main/index.js:48702  function fulfilled(value) { try { step(generator.next(value)); } catch (e) { re??
```

I can confirm this happens in v2.24.x (<= v2.24.3) but not v2.23.1. The cause is that "startInBackground" config migration occurs before storage content is put, but no config is available then (for the first use). This would not happen if you opened the app before, and that you have a config created.
