### PR TITLE
Reduce google permissions requirement

### DIFF
--- a/source/main/services/googleDrive.ts
+++ b/source/main/services/googleDrive.ts
@@ -8,7 +8,6 @@ import { logInfo, logWarn } from "../library/log";
 import {
     GOOGLE_AUTH_REDIRECT,
     GOOGLE_AUTH_TIMEOUT,
-    GOOGLE_DRIVE_SCOPES_PERMISSIVE,
     GOOGLE_DRIVE_SCOPES_STANDARD,
     GOOGLE_CLIENT_ID,
     GOOGLE_CLIENT_SECRET
@@ -25,11 +24,9 @@ export function addGoogleTokens(
     __googleDriveTokens[sourceID] = tokens;
 }
 
-async function authenticateGoogleDrive(
-    openPermissions: boolean = false
-): Promise<{ accessToken: string; refreshToken: string }> {
-    logInfo(`Authenticating Google Drive (permissive: ${openPermissions ? "yes" : "no"})`);
-    const scopes = openPermissions ? GOOGLE_DRIVE_SCOPES_PERMISSIVE : GOOGLE_DRIVE_SCOPES_STANDARD;
+async function authenticateGoogleDrive(): Promise<{ accessToken: string; refreshToken: string }> {
+    logInfo("Authenticating Google Drive");
+    const scopes = GOOGLE_DRIVE_SCOPES_STANDARD;
     const oauth2Client = getGoogleDriveOAuthClient();
     const url = oauth2Client.generateAuthUrl({
         access_type: "offline",

--- a/source/renderer/actions/addVault.ts
+++ b/source/renderer/actions/addVault.ts
@@ -13,7 +13,7 @@ export async function addNewVaultTarget(
     datasourceConfig: DatasourceConfig,
     password: string,
     createNew: boolean,
-    fileNameOverride: string = null
+    fileNameOverride: string | null = null
 ): Promise<VaultSourceID> {
     setBusy(true);
     const addNewVaultPromise = new Promise<VaultSourceID>((resolve, reject) => {

--- a/source/renderer/components/standalone/GoogleReAuthDialog.tsx
+++ b/source/renderer/components/standalone/GoogleReAuthDialog.tsx
@@ -35,7 +35,7 @@ export function GoogleReAuthDialog() {
     }, [googleReAuthState]);
     const authenticate = useCallback(() => {
         setBusy(true);
-        authenticateGoogleDrive(false)
+        authenticateGoogleDrive()
             .then(tokens => updateGoogleTokensForSource(sourceID, tokens))
             .then(() => {
                 setBusy(false);

--- a/source/shared/i18n/translations/ca_es.json
+++ b/source/shared/i18n/translations/ca_es.json
@@ -29,9 +29,7 @@
             "google-auth": {
                 "instr-1": "Pots seleccionar el nivell de permisos que utilitzarà Buttercup al accedir a la teva compte de <strong>Google Drive</strong>.",
                 "instr-2": "Seleccionar una configuració de permís <strong>oberta</strong> atorgarà a Buttercup accés a tots els arxius i carpetes del seu compte i els recursos compartits connectats.",
-"instr-3": "Seleccionar una configuració <i>no</i> oberta atorgarà a Buttercup accés als arxius que ha creat / accedit prèviament.",
-                "perm-label": "Permisos",
-                "perm-switch": "Obert"
+                "instr-3": "Seleccionar una configuració <i>no</i> oberta atorgarà a Buttercup accés als arxius que ha creat / accedit prèviament."
             },
             "webdav-auth": {
                 "password-label": "Contrasenya",

--- a/source/shared/i18n/translations/de.json
+++ b/source/shared/i18n/translations/de.json
@@ -29,9 +29,7 @@
             "google-auth": {
                 "instr-1": "Du kannst die Berechtigung auswählen, die Buttercup nutzen wird, während es auf deinen <strong>Google Drive</strong> Konto zugreift.",
                 "instr-2": "Wenn Du eine <strong>offene</strong> Berechtigung auswählst, erlaubst Du Buttercup auf alle deine Dateien und Ordner deines Accounts und verbundenen Freigaben zuzugreifen.",
-                "instr-3": "Wenn Du eine <i>nicht-</i>offene Berechtigung auswählst, erlaubst Du Buttercup auf Dateien zuzugreifen, die zuvor erstellt oder auf die zuvor zugegriffen wurde.",
-                "perm-label": "Berechtigungen",
-                "perm-switch": "Offen"
+                "instr-3": "Wenn Du eine <i>nicht-</i>offene Berechtigung auswählst, erlaubst Du Buttercup auf Dateien zuzugreifen, die zuvor erstellt oder auf die zuvor zugegriffen wurde."
             },
             "webdav-auth": {
                 "password-label": "Passwort",

--- a/source/shared/i18n/translations/en.json
+++ b/source/shared/i18n/translations/en.json
@@ -20,6 +20,11 @@
             "new-password": "Enter a new primary vault password:",
             "password-placeholder": "Vault password..."
         },
+        "copy-auth-link": {
+            "button": "Copy URL",
+            "title": "Copy authentication URL",
+            "url-copied": "Authentication URL copied to clipboard"
+        },
         "google-auth-button": "Authenticate",
         "google-auth-button-title": "Authenticate with Google Drive",
         "google-auth-error": "Google authentication failed",
@@ -29,9 +34,7 @@
             "google-auth": {
                 "instr-1": "You may select the level of permission that Buttercup will use while accessing your <strong>Google Drive</strong> account.",
                 "instr-2": "Selecting an <strong>open</strong> permission setting will grant Buttercup access to all files and folders in your account and connected shares.",
-                "instr-3": "Selecting a <i>non-</i>open setting will grant Buttercup access to files that it has created/accessed previously.",
-                "perm-label": "Permissions",
-                "perm-switch": "Open"
+                "instr-3": "Selecting a <i>non-</i>open setting will grant Buttercup access to files that it has created/accessed previously."
             },
             "webdav-auth": {
                 "password-label": "Password",

--- a/source/shared/i18n/translations/es.json
+++ b/source/shared/i18n/translations/es.json
@@ -29,9 +29,7 @@
             "google-auth": {
                 "instr-1": "Puede seleccionar el nivel de permisos que utilizará Buttercup al acceder a tu cuenta de <strong>Google Drive</strong>.",
                 "instr-2": "Seleccionar una configuración de permiso <strong>abierta</strong> otorgará a Buttercup acceso a todos los archivos y carpetas de su cuenta y los recursos compartidos conectados.",
-                "instr-3": "Seleccionar una configuración <i>no</i> abierta otorgará a Buttercup acceso a los archivos que ha creado / accedido previamente.",
-                "perm-label": "Permisos",
-                "perm-switch": "Abierto"
+                "instr-3": "Seleccionar una configuración <i>no</i> abierta otorgará a Buttercup acceso a los archivos que ha creado / accedido previamente."
             },
             "webdav-auth": {
                 "password-label": "Contraseña",

--- a/source/shared/i18n/translations/fi.json
+++ b/source/shared/i18n/translations/fi.json
@@ -29,9 +29,7 @@
             "google-auth": {
                 "instr-1": "Voit valita käyttöoikeustason, jota Buttercup käyttää käyttäessään <strong>Google Drive</strong> tiliäsi.",
                 "instr-2": "Selecting an <strong>open</strong> Avoimen käyttöoikeusasetuksen valitseminen antaa Buttercupille pääsyn kaikkiin tilisi tiedostoihin ja kansioihin sekä yhdistettyihin jaettuihin jakoihin.",
-                "instr-3": "<i>ei-</i>avoin asetuksen valitseminen antaa Buttercupille pääsyn tiedostoihin, jotka se on luonut tai käyttänyt aiemmin.",
-                "perm-label": "Käyttöoikeudet",
-                "perm-switch": "Avaa"
+                "instr-3": "<i>ei-</i>avoin asetuksen valitseminen antaa Buttercupille pääsyn tiedostoihin, jotka se on luonut tai käyttänyt aiemmin."
             },
             "webdav-auth": {
                 "password-label": "Salasana",

--- a/source/shared/i18n/translations/fr.json
+++ b/source/shared/i18n/translations/fr.json
@@ -29,9 +29,7 @@
             "google-auth": {
                 "instr-1": "Vous pouvez sélectionner le niveau de permission que Buttercup utilisera lors de l’accès à votre compte <strong>Google Drive</strong>.",
                 "instr-2": "En sélectionnant un paramètre de permission <strong>étendu</strong>, Buttercup aura accès à tous les fichiers et dossiers de votre compte et aux partages connectés.",
-                "instr-3": "La sélection d’un paramètre <i>non-</i>étendu permettra à Buttercup d'accéder aux fichiers qu’il a créés ou auxquels il a accédé précédemment.",
-                "perm-label": "Permissions",
-                "perm-switch": "Étendu"
+                "instr-3": "La sélection d’un paramètre <i>non-</i>étendu permettra à Buttercup d'accéder aux fichiers qu’il a créés ou auxquels il a accédé précédemment."
             },
             "webdav-auth": {
                 "password-label": "Mot de passe",

--- a/source/shared/i18n/translations/it.json
+++ b/source/shared/i18n/translations/it.json
@@ -29,9 +29,7 @@
             "google-auth": {
                 "instr-1": "Puoi scegliere il livello di autorizzazione che Buttercup userà durante l'accesso all'account <strong>Google Drive</strong>.",
                 "instr-2": "Seleziona un livello di autorizzazione <strong>aperto</strong> garantirà a Buttercup l'accesso a tutti i file e le cartelle nell'account e alle condivisioni.",
-                "instr-3": "Seleziona un livello di autorizzazione <i>non-</i>aperto garantirà a Buttercup l'accesso ai file che sono stati creati o a cui ha avuto accesso precedentemente.",
-                "perm-label": "Permessi",
-                "perm-switch": "Apri"
+                "instr-3": "Seleziona un livello di autorizzazione <i>non-</i>aperto garantirà a Buttercup l'accesso ai file che sono stati creati o a cui ha avuto accesso precedentemente."
             },
             "webdav-auth": {
                 "password-label": "Password",

--- a/source/shared/i18n/translations/ja.json
+++ b/source/shared/i18n/translations/ja.json
@@ -29,9 +29,7 @@
             "google-auth": {
                 "instr-1": "あなたの <strong>Google Drive</strong> アカウントにアクセスする際に、Buttercupが使用する許可レベルを選択することができます。",
                 "instr-2": "<strong>open</strong> 設定を選択すると、アカウント内のすべてのファイルとフォルダ、および接続された共有へのアクセスが許可されます。",
-                "instr-3": "open<i>以外の</i> 設定を選択すると、Buttercupが以前に作成/アクセスしたファイルにアクセスできるようになります。",
-                "perm-label": "権限",
-                "perm-switch": "開く"
+                "instr-3": "open<i>以外の</i> 設定を選択すると、Buttercupが以前に作成/アクセスしたファイルにアクセスできるようになります。"
             },
             "webdav-auth": {
                 "password-label": "パスワード",

--- a/source/shared/i18n/translations/pl.json
+++ b/source/shared/i18n/translations/pl.json
@@ -29,9 +29,7 @@
             "google-auth": {
                 "instr-1": "Możesz wybrać poziom uprawnień, których będzie używać Buttercup podczas uzyskiwania dostępu do twojego konta <strong>Google Drive</strong>.",
                 "instr-2": "Wybranie <strong>pełnych</strong> uprawnień zapewni Buttercup dostęp do wszystkich plików i folderów na twoim koncie oraz podłączonych udostępnień.",
-                "instr-3": "Wybranie <i>nie-</i>pełnych uprawnień zapewni Buttercup dostęp do plików, które menedżer haseł wcześniej utworzył lub do których uzyskał dostęp.",
-                "perm-label": "Uprawnienia",
-                "perm-switch": "Pełne"
+                "instr-3": "Wybranie <i>nie-</i>pełnych uprawnień zapewni Buttercup dostęp do plików, które menedżer haseł wcześniej utworzył lub do których uzyskał dostęp."
             },
             "webdav-auth": {
                 "password-label": "Hasło",

--- a/source/shared/i18n/translations/pt-br.json
+++ b/source/shared/i18n/translations/pt-br.json
@@ -29,9 +29,7 @@
             "google-auth": {
                 "instr-1": "É necessário selecionar o modelo de permissão que o Buttercup usará ao acessar sua conta do <strong>Google Drive</strong>.",
                 "instr-2": "Ao selecionar o modelo de permissão <strong>'Aberta'</strong>, será concedida ao Buttercup o acesso a todos os arquivos e pastas da sua conta e compartilhamentos conectados.",
-                "instr-3": "Selecionar a configuração <i>não-aberto</i> concederá ao Buttercup acesso aos arquivos que ele criou/acessou anteriormente.",
-                "perm-label": "Permissão",
-                "perm-switch": "Aberta" 
+                "instr-3": "Selecionar a configuração <i>não-aberto</i> concederá ao Buttercup acesso aos arquivos que ele criou/acessou anteriormente."
             },
             "webdav-auth": {
                 "password-label": "Senha",

--- a/source/shared/i18n/translations/ro.json
+++ b/source/shared/i18n/translations/ro.json
@@ -29,9 +29,7 @@
             "google-auth": {
                 "instr-1": "Poți selecta nivelul permisiunilor pe care Buttercup le va folosi în timp ce-ți accesează contul <strong>Google Drive</strong>.",
                 "instr-2": "Selectând permisiunea <strong>deschisă</strong>, vei permite aplicației Buttercup să acceseze toate fișierele și dosarele contului tău și totodată toate conexiunile împărtășite.",
-                "instr-3": "Selectând permisiunea <i>non-</i>deschisă, vei permite aplicației Buttercup să acceseze doar fișierele pe care le-a creat/accesat anterior.",
-                "perm-label": "Permisiune",
-                "perm-switch": "Deschisă"
+                "instr-3": "Selectând permisiunea <i>non-</i>deschisă, vei permite aplicației Buttercup să acceseze doar fișierele pe care le-a creat/accesat anterior."
             },
             "webdav-auth": {
                 "password-label": "Parolă",

--- a/source/shared/i18n/translations/zh_cn.json
+++ b/source/shared/i18n/translations/zh_cn.json
@@ -29,9 +29,7 @@
             "google-auth": {
                 "instr-1": "您可以选择 Buttercup 在访问您的 <strong>Google Drive</strong> 帐户时使用的权限级别。",
                 "instr-2": "选择<strong>打开</strong>权限设置将授予 Buttercup 访问您帐户和关联共享中的所有文件和文件夹的权限。",
-                "instr-3": "选择<i>非</i>打开设置将授予 Buttercup 访问它之前创建/访问的文件的权限。",
-                "perm-label": "权限",
-                "perm-switch": "打开"
+                "instr-3": "选择<i>非</i>打开设置将授予 Buttercup 访问它之前创建/访问的文件的权限。"
             },
             "webdav-auth": {
                 "password-label": "密码",

--- a/source/shared/symbols.ts
+++ b/source/shared/symbols.ts
@@ -11,10 +11,6 @@ export const GOOGLE_DRIVE_SCOPES_STANDARD = [
     ...GOOGLE_DRIVE_BASE_SCOPES,
     "https://www.googleapis.com/auth/drive.file" // Per-file access
 ];
-export const GOOGLE_DRIVE_SCOPES_PERMISSIVE = [
-    ...GOOGLE_DRIVE_BASE_SCOPES,
-    "https://www.googleapis.com/auth/drive"
-];
 export const GOOGLE_CLIENT_ID =
     "327941947801-fumr4be9juk0bu3ekfuq9fr5bm7trh30.apps.googleusercontent.com";
 export const GOOGLE_CLIENT_SECRET = "2zCBNDSXp1yIu5dyE5BVUWQZ";

--- a/source/shared/types.ts
+++ b/source/shared/types.ts
@@ -41,7 +41,10 @@ export interface Config {
     windowY: null | number;
 }
 
-export type DatasourceConfig = { [key: string]: string } & { type: SourceType };
+export interface DatasourceConfig {
+    type: SourceType | null;
+    [key: string]: string | null;
+}
 
 export interface Language {
     name: string;


### PR DESCRIPTION
Google has introduced increased restrictions and requirements for using open Drive permissions. This PR removes our requirement on our most permissive permissions scopes on Google Drive, requiring that Drive files are modified by Buttercup before being accessible.