### PR TITLE
fix(groups): allow to create a group with no parent

### DIFF
--- a/source/renderer/components/vault/GroupsList.tsx
+++ b/source/renderer/components/vault/GroupsList.tsx
@@ -215,9 +215,6 @@ export const GroupsList = () => {
         if (groupEditID !== null && groupEditID !== -1) {
             onRenameGroup(groupEditID, newGroupName);
         } else {
-            if (!parentGroupID) {
-                throw new Error("No parent ID specified");
-            }
             onCreateGroup(parentGroupID, newGroupName);
         }
         closeEditDialog();

--- a/source/renderer/components/vault/VaultContext.tsx
+++ b/source/renderer/components/vault/VaultContext.tsx
@@ -37,7 +37,7 @@ export interface VaultContextState {
 
     batchDeleteItems: (action: { groupIDs?: Array<GroupID>; entryIDs?: Array<EntryID>; }) => void;
     onCollapseGroup: (group: GroupTreeNodeInfo) => void;
-    onCreateGroup: (parentID: GroupID, groupTitle: string) => void;
+    onCreateGroup: (parentID: GroupID | null, groupTitle: string) => void;
     onExpandGroup: (group: GroupTreeNodeInfo) => void;
     onSelectGroup: (groupID: GroupID | null) => void;
     onGroupFilterTermChange: (term: string) => void;


### PR DESCRIPTION
Hi 👋 

`parentGroupID` is not always mandatory specially when you create a group at the root of the vault

Closes: #1369